### PR TITLE
Crc complex

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -143,4 +143,16 @@ public interface Table {
    */
   void checkpoint(Engine engine, long version)
       throws TableNotFoundException, CheckpointAlreadyExistsException, IOException;
+
+  /**
+   * Checkpoint the table at given version. It writes a single checkpoint file.
+   *
+   * @param engine {@link Engine} instance to use.
+   * @param version Version to checkpoint.
+   * @throws TableNotFoundException if the table is not found
+   * @throws CheckpointAlreadyExistsException if a checkpoint already exists at the given version
+   * @throws IOException for any I/O error.
+   * @since 3.2.0
+   */
+  void checksum(Engine engine, long version) throws TableNotFoundException, IOException;
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/hook/PostCommitHook.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/hook/PostCommitHook.java
@@ -40,7 +40,8 @@ public interface PostCommitHook {
      * transaction commits. This operation has a minimal latency with no requirement of reading
      * previous checkpoint or logs.
      */
-    CHECKSUM_SIMPLE
+    CHECKSUM_SIMPLE,
+    CHECKSUM_FULL
   }
 
   /** Invokes the post commit operation whose implementation must be thread safe. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -135,6 +135,12 @@ public class TableImpl implements Table {
   }
 
   @Override
+  public void checksum(Engine engine, long version)
+      throws TableNotFoundException, CheckpointAlreadyExistsException, IOException {
+    snapshotManager.checksum(engine, version);
+  }
+
+  @Override
   public TransactionBuilder createTransactionBuilder(
       Engine engine, String engineInfo, Operation operation) {
     return new TransactionBuilderImpl(this, engineInfo, operation);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumWriter.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumWriter.java
@@ -51,9 +51,7 @@ public class ChecksumWriter {
           engine
               .getJsonHandler()
               .writeJsonFileAtomically(
-                  newChecksumPath.toString(),
-                  singletonCloseableIterator(toRow(crcInfo)),
-                  false /* overwrite */);
+                  newChecksumPath.toString(), singletonCloseableIterator(toRow(crcInfo)), false);
           logger.info("Write checksum file `{}` succeeds", newChecksumPath);
           return null;
         },

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/hook/ChecksumFullHook.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/hook/ChecksumFullHook.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.hook;
+
+import io.delta.kernel.Table;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.hook.PostCommitHook;
+import io.delta.kernel.internal.fs.Path;
+import java.io.IOException;
+
+public class ChecksumFullHook implements PostCommitHook {
+
+  private final Path tablePath;
+  private final long checksumVersion;
+
+  public ChecksumFullHook(Path tablePath, long checksumVersion) {
+    this.tablePath = tablePath;
+    this.checksumVersion = checksumVersion;
+  }
+
+  @Override
+  public void threadSafeInvoke(Engine engine) throws IOException {
+    Table.forPath(engine, tablePath.toString()).checksum(engine, checksumVersion);
+  }
+
+  @Override
+  public PostCommitHookType getType() {
+    return PostCommitHookType.CHECKPOINT;
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/ChecksumWriterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/ChecksumWriterSuite.scala
@@ -59,7 +59,8 @@ class ChecksumWriterSuite extends AnyFunSuite with MockEngineUtils {
 
       checksumWriter.writeCheckSum(
         mockEngine(jsonHandler = jsonHandler),
-        new CRCInfo(version, metadata, protocol, tableSizeBytes, numFiles, txn)
+        new CRCInfo(version, metadata, protocol, tableSizeBytes, numFiles, txn),
+        false
       )
 
       verifyChecksumFile(jsonHandler, version)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumSimpleComparisonSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumSimpleComparisonSuite.scala
@@ -126,7 +126,6 @@ class ChecksumSimpleComparisonSuite extends AnyFunSuite with TestUtils {
   }
 
   private def readCrcInfoFromChecksumFull(engine: Engine, path: String, version: Long): CRCInfo = {
-//    assert(Files.deleteIfExists(buildCrcPath(path, version)))
     defaultEngine.getFileSystemClient.delete(buildCrcPath(path, version).toString)
     Table
       .forPath(engine, path)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
