### PR TITLE
fix attempt

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -131,11 +131,16 @@ object SuiteGeneratorConfig {
       "MergeIntoTempViewsTests",
       "MergeIntoNestedDataTests",
       "MergeIntoUnlimitedMergeClausesTests",
+      "MergeIntoAnalysisExceptionTests",
+      "MergeIntoExtendedSyntaxTests",
       "MergeIntoSuiteBaseMiscTests",
       "MergeIntoNotMatchedBySourceSuite",
+      "MergeIntoNotMatchedBySourceWithCDCSuite",
       "MergeIntoSchemaEvolutionCoreTests",
       "MergeIntoSchemaEvolutionBaseTests",
+      "MergeIntoSchemaEvolutionStoreAssignmentPolicyTests",
       "MergeIntoSchemaEvolutionNotMatchedBySourceTests",
+      "MergeIntoNestedStructInMapEvolutionTests",
       "MergeIntoNestedStructEvolutionTests"
     )
     val MERGE_SQL = List(
@@ -170,6 +175,33 @@ object SuiteGeneratorConfig {
    */
   lazy val TEST_GROUPS: List[TestGroup] = List(
     TestGroup(
+      name = "MergeSetupSuites",
+      imports = List(
+        importer"org.apache.spark.sql.delta._",
+        importer"org.apache.spark.sql.delta.cdc._",
+        importer"org.apache.spark.sql.delta.rowid._"
+      ),
+      testConfigs = List(
+        TestConfig(
+          List("MergeIntoMaterializeSourceTests"),
+          List(
+            List(Dims.MERGE_PERSISTENT_DV_OFF)
+          )
+        ),
+        TestConfig(
+          List("RowTrackingMergeCommonTests"),
+          List(Dims.CDC.asOptional).prependToAll(
+            List(Dims.MERGE_ROW_TRACKING_DV.asOptional),
+            List(Dims.PERSISTENT_DV_OFF, Dims.MERGE_PERSISTENT_DV_OFF)
+          ) :::
+          List(Dims.COLUMN_MAPPING).prependToAll(
+            List(),
+            List(Dims.CDC, Dims.MERGE_ROW_TRACKING_DV)
+          )
+        )
+      )
+    ),
+    TestGroup(
       name = "MergeSuites",
       imports = List(
         importer"org.apache.spark.sql.delta._",
@@ -191,23 +223,6 @@ object SuiteGeneratorConfig {
             List(Dims.PATH_BASED, Dims.MERGE_DVS, Dims.PREDPUSH),
             List(Dims.PATH_BASED, Dims.CDC),
             List(Dims.PATH_BASED, Dims.CDC, Dims.MERGE_DVS, Dims.PREDPUSH)
-          )
-        ),
-        TestConfig(
-          List("MergeIntoMaterializeSourceTests"),
-          List(
-            List(Dims.MERGE_PERSISTENT_DV_OFF)
-          )
-        ),
-        TestConfig(
-          List("RowTrackingMergeCommonTests"),
-          List(Dims.CDC.asOptional).prependToAll(
-            List(Dims.MERGE_ROW_TRACKING_DV.asOptional),
-            List(Dims.PERSISTENT_DV_OFF, Dims.MERGE_PERSISTENT_DV_OFF)
-          ) :::
-          List(Dims.COLUMN_MAPPING).prependToAll(
-            List(),
-            List(Dims.CDC, Dims.MERGE_ROW_TRACKING_DV)
           )
         )
       )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.Row
 
-trait MergeIntoNotMatchedBySourceSuite extends MergeIntoSuiteBaseMixin {
+trait MergeIntoNotMatchedBySourceWithCDCSuite extends MergeIntoSuiteBaseMixin {
   import testImplicits._
 
   /**
@@ -59,89 +59,6 @@ trait MergeIntoNotMatchedBySourceSuite extends MergeIntoSuiteBaseMixin {
       }
     }
   }
-
-  // Test analysis errors with NOT MATCHED BY SOURCE clauses.
-  testMergeAnalysisException(
-    "error on multiple not matched by source update clauses without condition")(
-    mergeOn = "s.key = t.key",
-    updateNotMatched(condition = "t.key == 3", set = "value = 2 * value"),
-    updateNotMatched(set = "value = 3 * value"),
-    updateNotMatched(set = "value = 4 * value"))(
-    expectedErrorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
-    expectedMessageParameters = Map.empty)
-
-  testMergeAnalysisException(
-    "error on multiple not matched by source update/delete clauses without condition")(
-    mergeOn = "s.key = t.key",
-    updateNotMatched(condition = "t.key == 3", set = "value = 2 * value"),
-    deleteNotMatched(),
-    updateNotMatched(set = "value = 4 * value"))(
-    expectedErrorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
-    expectedMessageParameters = Map.empty)
-
-  testMergeAnalysisException(
-    "error on non-empty condition following empty condition in not matched by source " +
-      "update clauses")(
-    mergeOn = "s.key = t.key",
-    updateNotMatched(set = "value = 2 * value"),
-    updateNotMatched(condition = "t.key < 3", set = "value = value"))(
-    expectedErrorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
-    expectedMessageParameters = Map.empty)
-
-  testMergeAnalysisException(
-    "error on non-empty condition following empty condition in not matched by source " +
-      "delete clauses")(
-    mergeOn = "s.key = t.key",
-    deleteNotMatched(),
-    deleteNotMatched(condition = "t.key < 3"))(
-    expectedErrorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
-    expectedMessageParameters = Map.empty)
-
-  testMergeAnalysisException("update not matched condition - unknown reference")(
-    mergeOn = "s.key = t.key",
-    updateNotMatched(condition = "unknownAttrib > 1", set = "tgtValue = tgtValue + 1"))(
-    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
-    expectedMessageParameters = Map(
-      "sqlExpr" -> "unknownAttrib",
-      "clause" -> "UPDATE condition",
-      "cols" -> "t.key, t.tgtValue"))
-
-  testMergeAnalysisException("update not matched condition - aggregation function")(
-    mergeOn = "s.key = t.key",
-    updateNotMatched(condition = "max(0) > 0", set = "tgtValue = tgtValue + 1"))(
-    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
-    expectedMessageParameters = Map(
-      "operation" -> "UPDATE condition of MERGE operation",
-      "predicate" -> "(condition = (max(0) > 0))"))
-
-  testMergeAnalysisException("update not matched condition - subquery")(
-    mergeOn = "s.key = t.key",
-    updateNotMatched(condition = "tgtValue in (select value from t)", set = "tgtValue = 1"))(
-    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
-    expectedMessageParameters = Map("relationName" -> "`t`"))
-
-  testMergeAnalysisException("delete not matched condition - unknown reference")(
-    mergeOn = "s.key = t.key",
-    deleteNotMatched(condition = "unknownAttrib > 1"))(
-    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
-    expectedMessageParameters = Map(
-      "sqlExpr" -> "unknownAttrib",
-      "clause" -> "DELETE condition",
-      "cols" -> "t.key, t.tgtValue"))
-
-  testMergeAnalysisException("delete not matched condition - aggregation function")(
-    mergeOn = "s.key = t.key",
-    deleteNotMatched(condition = "max(0) > 0"))(
-    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
-    expectedMessageParameters = Map(
-      "operation" -> "DELETE condition of MERGE operation",
-      "predicate" -> "(condition = (max(0) > 0))"))
-
-  testMergeAnalysisException("delete not matched condition - subquery")(
-    mergeOn = "s.key = t.key",
-    deleteNotMatched(condition = "tgtValue in (select tgtValue from t)"))(
-    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
-    expectedMessageParameters = Map("relationName" -> "`t`"))
 
   // Test correctness with NOT MATCHED BY SOURCE clauses.
   testExtendedMergeWithCDC("all 3 types of match clauses without conditions")(
@@ -500,6 +417,93 @@ trait MergeIntoNotMatchedBySourceSuite extends MergeIntoSuiteBaseMixin {
       (7, 3) // Not matched by source, no change
     ),
     cdc = Seq.empty)
+}
+
+trait MergeIntoNotMatchedBySourceSuite extends MergeIntoSuiteBaseMixin {
+  import testImplicits._
+
+  // Test analysis errors with NOT MATCHED BY SOURCE clauses.
+  testMergeAnalysisException(
+    "error on multiple not matched by source update clauses without condition")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "t.key == 3", set = "value = 2 * value"),
+    updateNotMatched(set = "value = 3 * value"),
+    updateNotMatched(set = "value = 4 * value"))(
+    expectedErrorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
+    expectedMessageParameters = Map.empty)
+
+  testMergeAnalysisException(
+    "error on multiple not matched by source update/delete clauses without condition")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "t.key == 3", set = "value = 2 * value"),
+    deleteNotMatched(),
+    updateNotMatched(set = "value = 4 * value"))(
+    expectedErrorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
+    expectedMessageParameters = Map.empty)
+
+  testMergeAnalysisException(
+    "error on non-empty condition following empty condition in not matched by source " +
+      "update clauses")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(set = "value = 2 * value"),
+    updateNotMatched(condition = "t.key < 3", set = "value = value"))(
+    expectedErrorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
+    expectedMessageParameters = Map.empty)
+
+  testMergeAnalysisException(
+    "error on non-empty condition following empty condition in not matched by source " +
+      "delete clauses")(
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(),
+    deleteNotMatched(condition = "t.key < 3"))(
+    expectedErrorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
+    expectedMessageParameters = Map.empty)
+
+  testMergeAnalysisException("update not matched condition - unknown reference")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "unknownAttrib > 1", set = "tgtValue = tgtValue + 1"))(
+    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
+    expectedMessageParameters = Map(
+      "sqlExpr" -> "unknownAttrib",
+      "clause" -> "UPDATE condition",
+      "cols" -> "t.key, t.tgtValue"))
+
+  testMergeAnalysisException("update not matched condition - aggregation function")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "max(0) > 0", set = "tgtValue = tgtValue + 1"))(
+    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
+    expectedMessageParameters = Map(
+      "operation" -> "UPDATE condition of MERGE operation",
+      "predicate" -> "(condition = (max(0) > 0))"))
+
+  testMergeAnalysisException("update not matched condition - subquery")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "tgtValue in (select value from t)", set = "tgtValue = 1"))(
+    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
+    expectedMessageParameters = Map("relationName" -> "`t`"))
+
+  testMergeAnalysisException("delete not matched condition - unknown reference")(
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(condition = "unknownAttrib > 1"))(
+    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
+    expectedMessageParameters = Map(
+      "sqlExpr" -> "unknownAttrib",
+      "clause" -> "DELETE condition",
+      "cols" -> "t.key, t.tgtValue"))
+
+  testMergeAnalysisException("delete not matched condition - aggregation function")(
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(condition = "max(0) > 0"))(
+    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
+    expectedMessageParameters = Map(
+      "operation" -> "DELETE condition of MERGE operation",
+      "predicate" -> "(condition = (max(0) > 0))"))
+
+  testMergeAnalysisException("delete not matched condition - subquery")(
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(condition = "tgtValue in (select tgtValue from t)"))(
+    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
+    expectedMessageParameters = Map("relationName" -> "`t`"))
 
   test("special character in path - not matched by source delete", NameBasedAccessIncompatible) {
     withTempDir { tempDir =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -34,6 +34,10 @@ import org.apache.spark.util.Utils
 trait MergeIntoSchemaEvolutionMixin extends QueryTest {
   self: SharedSparkSession with MergeIntoTestUtils =>
 
+  protected implicit def strToJsonSeq(str: String): Seq[String] = {
+    str.split("\n").filter(_.trim.length > 0)
+  }
+
   /**
    * Test runner used by most non-nested schema evolution tests. Runs the MERGE operation once with
    * schema evolution disabled then with schema evolution enabled. Tests must provide for each case
@@ -586,95 +590,6 @@ trait MergeIntoSchemaEvolutionBaseTests extends MergeIntoSchemaEvolutionMixin {
     confs = Seq(SQLConf.STORE_ASSIGNMENT_POLICY.key -> "LEGACY")
   )
 
-  // Upcasting is always allowed.
-  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values)
-  testEvolution("upcast int source type into long target, storeAssignmentPolicy = " +
-    s"$storeAssignmentPolicy")(
-    targetData = Seq((0, 0L), (1, 1L), (3, 3L)).toDF("key", "value"),
-    sourceData = Seq((1, 1), (2, 2)).toDF("key", "value"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected =
-      ((0, 0L) +: (1, 1L) +: (2, 2L) +: (3, 3L) +: Nil).toDF("key", "value"),
-    expectedWithoutEvolution =
-      ((0, 0L) +: (1, 1L) +: (2, 2L) +: (3, 3L) +: Nil).toDF("key", "value"),
-    confs = Seq(
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
-      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
-  )
-
-  // Casts that are not valid implicit casts (e.g. string -> boolean) are never allowed with
-  // schema evolution enabled and allowed only when storeAssignmentPolicy is LEGACY or ANSI when
-  // schema evolution is disabled.
-  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
-  testEvolution("invalid implicit cast string source type into boolean target, " +
-    s"storeAssignmentPolicy = $storeAssignmentPolicy")(
-    targetData = Seq((0, true), (1, false), (3, true)).toDF("key", "value"),
-    sourceData = Seq((1, "true"), (2, "false")).toDF("key", "value"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expectErrorContains = "Failed to merge incompatible data types BooleanType and StringType",
-    expectedWithoutEvolution = ((0, true) +: (1, true) +: (2, false) +: (3, true) +: Nil)
-      .toDF("key", "value"),
-    confs = Seq(
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
-      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
-  )
-
-  // Casts that are not valid implicit casts (e.g. string -> boolean) are not allowed with
-  // storeAssignmentPolicy = STRICT.
-  testEvolution("invalid implicit cast string source type into boolean target, " +
-   s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}")(
-    targetData = Seq((0, true), (1, false), (3, true)).toDF("key", "value"),
-    sourceData = Seq((1, "true"), (2, "false")).toDF("key", "value"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expectErrorContains = "Failed to merge incompatible data types BooleanType and StringType",
-    expectErrorWithoutEvolutionContains = "cannot up cast s.value from \"string\" to \"boolean\"",
-    confs = Seq(
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
-      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
-  )
-
-  // Valid implicit casts that are not upcasts (e.g. string -> int) are allowed with
-  // storeAssignmentPolicy = LEGACY or ANSI.
-  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
-  testEvolution("valid implicit cast string source type into int target, " +
-   s"storeAssignmentPolicy = ${storeAssignmentPolicy}")(
-    targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),
-    sourceData = Seq((1, "1"), (2, "2")).toDF("key", "value"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected = ((0, 0)+: (1, 1) +: (2, 2) +: (3, 3)  +: Nil).toDF("key", "value"),
-    expectedWithoutEvolution = ((0, 0) +: (1, 1) +: (2, 2) +: (3, 3) +: Nil).toDF("key", "value"),
-    confs = Seq(
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
-      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
-  )
-
-  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
-  testEvolution("valid implicit cast long source type into int target, " +
-   s"storeAssignmentPolicy = $storeAssignmentPolicy")(
-    targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),
-    sourceData = Seq((1, 1L), (2, 2L)).toDF("key", "value"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected = ((0, 0)+: (1, 1) +: (2, 2) +: (3, 3)  +: Nil).toDF("key", "value"),
-    expectedWithoutEvolution = ((0, 0) +: (1, 1) +: (2, 2) +: (3, 3) +: Nil).toDF("key", "value"),
-    confs = Seq(
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
-      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
-  )
-
-  // Valid implicit casts that are not upcasts (e.g. string -> int) are rejected with
-  // storeAssignmentPolicy = STRICT.
-  testEvolution("valid implicit cast string source type into int target, " +
-   s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}")(
-    targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),
-    sourceData = Seq((1, "1"), (2, "2")).toDF("key", "value"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expectErrorContains = "cannot up cast s.value from \"string\" to \"int\"",
-    expectErrorWithoutEvolutionContains = "cannot up cast s.value from \"string\" to \"int\"",
-    confs = Seq(
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
-      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
-  )
-
   // This is kinda bug-for-bug compatibility. It doesn't really make sense that infinity is casted
   // to int as Int.MaxValue, but that's the behavior.
   testEvolution("write double into int column")(
@@ -690,31 +605,6 @@ trait MergeIntoSchemaEvolutionBaseTests extends MergeIntoSchemaEvolutionMixin {
     // Disable ANSI as this test needs to cast Double.PositiveInfinity to int
     confs = Seq(SQLConf.STORE_ASSIGNMENT_POLICY.key -> "LEGACY")
   )
-
-  testEvolution("multiple casts with storeAssignmentPolicy = STRICT")(
-    targetData = Seq((0L, "0"), (1L, "10"), (3L, "30")).toDF("key", "value"),
-    sourceData = Seq((1, 1L), (2, 2L)).toDF("key", "value"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected =
-      ((0L, "0") +: (1L, "1") +: (2L, "2") +: (3L, "30") +: Nil).toDF("key", "value"),
-    expectedWithoutEvolution =
-      ((0L, "0") +: (1L, "1") +: (2L, "2") +: (3L, "30") +: Nil).toDF("key", "value"),
-    confs = Seq(
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
-      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false"))
-
-  testEvolution("new column with storeAssignmentPolicy = STRICT")(
-    targetData = Seq((0, 0), (1, 10), (3, 30)).toDF("key", "value"),
-    sourceData = Seq((1, 1, "one"), (2, 2, "two")).toDF("key", "value", "extra"),
-    clauses = update("value = CAST(s.value AS short)") :: insert("*") :: Nil,
-    expected =
-      ((0, 0, null) +: (1, 1, null) +: (2, 2, "two") +: (3, 30, null) +: Nil)
-        .toDF("key", "value", "extra"),
-    expectedWithoutEvolution =
-      ((0, 0) +: (1, 1) +: (2, 2) +: (3, 30) +: Nil).toDF("key", "value"),
-    confs = Seq(
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
-      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false"))
 
   testEvolution("extra nested column in source - insert")(
     targetData = Seq((1, (1, 10))).toDF("key", "x"),
@@ -1054,118 +944,6 @@ trait MergeIntoSchemaEvolutionBaseTests extends MergeIntoSchemaEvolutionMixin {
     }
   }
 
-  testNestedStructsEvolution("nested field assignment qualified with source alias")(
-    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
-    source = Seq("""{ "a": 3, "t": { "a": 5 } }"""),
-    targetSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    sourceSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    cond = "1 = 1",
-    clauses = update("s.t.a = s.t.a") :: Nil,
-    // Assigning to the source is just wrong and should fail.
-    result = Seq("""{ "a": 1, "t": { "a": 5 } }"""),
-    resultSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    expectErrorWithoutEvolutionContains = "cannot resolve s.t.a in UPDATE")
-
-  testNestedStructsEvolution("existing top-level column assignment qualified with target alias")(
-    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
-    source = Seq("""{ "a": 3, "t": { "a": 5 } }"""),
-    targetSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    sourceSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    cond = "1 = 1",
-    // This succeeds and updates 'a': the fully qualified column name 't.a' gets precedence over
-    // the unqualified struct field name '(t.)t.a' to resolve the ambiguity.
-    clauses = update("t.a = s.a") :: Nil,
-    result = Seq("""{ "a": 3, "t": { "a": 2 } }"""),
-    resultSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    resultWithoutEvolution = Seq("""{ "a": 3, "t": { "a": 2 } }"""))
-
-  testNestedStructsEvolution("existing nested field assignment qualified with target alias")(
-    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
-    source = Seq("""{ "a": 3, "t": { "a": 5 } }"""),
-    targetSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    sourceSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    cond = "1 = 1",
-    // This is unambiguous: and resolves to the struct field 't.t.a' during resolution
-    clauses = update("t.t.a = s.t.a") :: Nil,
-    result = Seq("""{ "a": 1, "t": { "a": 5 } }"""),
-    resultSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    resultWithoutEvolution = Seq("""{ "a": 1, "t": { "a": 5 } }"""))
-
-  testNestedStructsEvolution("new top-level column assignment qualified with target alias")(
-    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
-    source = Seq("""{ "a": 3, "b": 4, "t": { "a": 5, "b": 6 } }"""),
-    targetSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    sourceSchema = new StructType()
-      .add("a", IntegerType)
-      .add("b", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)
-        .add("b", IntegerType)),
-    cond = "1 = 1",
-    clauses = update("t.b = s.b") :: Nil,
-    result = Seq("""{ "a": 1, "t": { "a": 2, "b": 4 } }"""),
-    resultSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)
-        .add("b", IntegerType)),
-    expectErrorWithoutEvolutionContains = "No such struct field `b` in `a`")
-
-  testNestedStructsEvolution("new nested field assignment qualified with target alias")(
-    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
-    source = Seq("""{ "a": 3, "b": 4, "t": { "a": 5, "b": 6 } }"""),
-    targetSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)),
-    sourceSchema = new StructType()
-      .add("a", IntegerType)
-      .add("b", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)
-        .add("b", IntegerType)),
-    cond = "1 = 1",
-    clauses = update("t.t.b = s.t.b") :: Nil,
-    // t.t.b gets resolved to source struct t, accessing nested field t.t.b which doesn't exist.
-    expectErrorContains = "No such struct field `t` in `a`, `b`",
-    resultSchema = new StructType()
-      .add("a", IntegerType)
-      .add("t", new StructType()
-        .add("a", IntegerType)
-        .add("b", IntegerType)),
-    // t.t.b: t.t gets resolved to target t with nested field b which doesn't exist in fields (a)
-    expectErrorWithoutEvolutionContains = "No such struct field `b` in `a`")
-
   testEvolutionWithoutTableAliases(
     "existing top-level column assignment qualified with target name")(
     targetData = Seq((0, 1)).toDF("a", "nested_a")
@@ -1204,6 +982,126 @@ trait MergeIntoSchemaEvolutionBaseTests extends MergeIntoSchemaEvolutionMixin {
     // target.target.b: target.target gets resolved to target table 'target' column with nested
     // field b which doesn't exist.
     expectErrorWithoutEvolutionContains = "No such struct field `b` in `a`")
+}
+
+trait MergeIntoSchemaEvolutionStoreAssignmentPolicyTests extends MergeIntoSchemaEvolutionMixin {
+  self: MergeIntoTestUtils with SharedSparkSession =>
+  import testImplicits._
+
+  // Upcasting is always allowed.
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values)
+  testEvolution("upcast int source type into long target, storeAssignmentPolicy = " +
+    s"$storeAssignmentPolicy")(
+    targetData = Seq((0, 0L), (1, 1L), (3, 3L)).toDF("key", "value"),
+    sourceData = Seq((1, 1), (2, 2)).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected =
+      ((0, 0L) +: (1, 1L) +: (2, 2L) +: (3, 3L) +: Nil).toDF("key", "value"),
+    expectedWithoutEvolution =
+      ((0, 0L) +: (1, 1L) +: (2, 2L) +: (3, 3L) +: Nil).toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  // Casts that are not valid implicit casts (e.g. string -> boolean) are never allowed with
+  // schema evolution enabled and allowed only when storeAssignmentPolicy is LEGACY or ANSI when
+  // schema evolution is disabled.
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
+  testEvolution("invalid implicit cast string source type into boolean target, " +
+    s"storeAssignmentPolicy = $storeAssignmentPolicy")(
+    targetData = Seq((0, true), (1, false), (3, true)).toDF("key", "value"),
+    sourceData = Seq((1, "true"), (2, "false")).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expectErrorContains = "Failed to merge incompatible data types BooleanType and StringType",
+    expectedWithoutEvolution = ((0, true) +: (1, true) +: (2, false) +: (3, true) +: Nil)
+      .toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  // Casts that are not valid implicit casts (e.g. string -> boolean) are not allowed with
+  // storeAssignmentPolicy = STRICT.
+  testEvolution("invalid implicit cast string source type into boolean target, " +
+   s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}")(
+    targetData = Seq((0, true), (1, false), (3, true)).toDF("key", "value"),
+    sourceData = Seq((1, "true"), (2, "false")).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expectErrorContains = "Failed to merge incompatible data types BooleanType and StringType",
+    expectErrorWithoutEvolutionContains = "cannot up cast s.value from \"string\" to \"boolean\"",
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  // Valid implicit casts that are not upcasts (e.g. string -> int) are allowed with
+  // storeAssignmentPolicy = LEGACY or ANSI.
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
+  testEvolution("valid implicit cast string source type into int target, " +
+   s"storeAssignmentPolicy = ${storeAssignmentPolicy}")(
+    targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),
+    sourceData = Seq((1, "1"), (2, "2")).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = ((0, 0)+: (1, 1) +: (2, 2) +: (3, 3)  +: Nil).toDF("key", "value"),
+    expectedWithoutEvolution = ((0, 0) +: (1, 1) +: (2, 2) +: (3, 3) +: Nil).toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
+  testEvolution("valid implicit cast long source type into int target, " +
+   s"storeAssignmentPolicy = $storeAssignmentPolicy")(
+    targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),
+    sourceData = Seq((1, 1L), (2, 2L)).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = ((0, 0)+: (1, 1) +: (2, 2) +: (3, 3)  +: Nil).toDF("key", "value"),
+    expectedWithoutEvolution = ((0, 0) +: (1, 1) +: (2, 2) +: (3, 3) +: Nil).toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  // Valid implicit casts that are not upcasts (e.g. string -> int) are rejected with
+  // storeAssignmentPolicy = STRICT.
+  testEvolution("valid implicit cast string source type into int target, " +
+   s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}")(
+    targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),
+    sourceData = Seq((1, "1"), (2, "2")).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expectErrorContains = "cannot up cast s.value from \"string\" to \"int\"",
+    expectErrorWithoutEvolutionContains = "cannot up cast s.value from \"string\" to \"int\"",
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  testEvolution("multiple casts with storeAssignmentPolicy = STRICT")(
+    targetData = Seq((0L, "0"), (1L, "10"), (3L, "30")).toDF("key", "value"),
+    sourceData = Seq((1, 1L), (2, 2L)).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected =
+      ((0L, "0") +: (1L, "1") +: (2L, "2") +: (3L, "30") +: Nil).toDF("key", "value"),
+    expectedWithoutEvolution =
+      ((0L, "0") +: (1L, "1") +: (2L, "2") +: (3L, "30") +: Nil).toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false"))
+
+  testEvolution("new column with storeAssignmentPolicy = STRICT")(
+    targetData = Seq((0, 0), (1, 10), (3, 30)).toDF("key", "value"),
+    sourceData = Seq((1, 1, "one"), (2, 2, "two")).toDF("key", "value", "extra"),
+    clauses = update("value = CAST(s.value AS short)") :: insert("*") :: Nil,
+    expected =
+      ((0, 0, null) +: (1, 1, null) +: (2, 2, "two") +: (3, 30, null) +: Nil)
+        .toDF("key", "value", "extra"),
+    expectedWithoutEvolution =
+      ((0, 0) +: (1, 1) +: (2, 2) +: (3, 30) +: Nil).toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false"))
+
 }
 
 /**
@@ -1275,14 +1173,362 @@ trait MergeIntoSchemaEvolutionNotMatchedBySourceTests extends MergeIntoSchemaEvo
 /**
  * Trait collecting all tests for nested struct evolution.
  */
-trait MergeIntoNestedStructEvolutionTests extends MergeIntoSchemaEvolutionMixin {
+trait MergeIntoNestedStructInMapEvolutionTests extends MergeIntoSchemaEvolutionMixin {
   self: MergeIntoTestUtils with SharedSparkSession =>
 
   import testImplicits._
 
-  private implicit def strToJsonSeq(str: String): Seq[String] = {
-    str.split("\n").filter(_.trim.length > 0)
-  }
+  // scalastyle:off line.size.limit
+  // Struct evolution inside of map values.
+  testNestedStructsEvolution("new source column in map struct value")(
+    target =
+      """{ "key": "A", "map": { "key": { "a": 1 } } }
+         { "key": "C", "map": { "key": { "a": 3 } } }""",
+    source =
+      """{ "key": "A", "map": { "key": { "a": 2, "b": 2 } } }
+         { "key": "B", "map": { "key": { "a": 1, "b": 2 } } }""",
+    targetSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType))),
+    sourceSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", IntegerType))),
+    resultSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", IntegerType))),
+    clauses = update("*") :: insert("*") :: Nil,
+    result =
+      """{ "key": "A", "map": { "key": { "a": 2, "b": 2 } } }
+         { "key": "B", "map": { "key": { "a": 1, "b": 2 } } }
+         { "key": "C", "map": { "key": { "a": 3, "b": null } } }""",
+    expectErrorWithoutEvolutionContains = "Cannot cast")
+
+  testNestedStructsEvolution("new source column in nested map struct value")(
+    target =
+      """{"key": "A", "map": { "key": { "innerKey": { "a": 1 } } } }
+         {"key": "C", "map": { "key": { "innerKey": { "a": 3 } } } }""",
+    source =
+      """{"key": "A", "map": { "key": { "innerKey": { "a": 2, "b": 3 } } } }
+         {"key": "B", "map": { "key": { "innerKey": { "a": 2, "b": 3 } } } }""",
+    targetSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          MapType(StringType, new StructType().add("a", IntegerType)))),
+    sourceSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))),
+    resultSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))),
+    clauses = update("*") :: insert("*") :: Nil,
+    result =
+      """{"key": "A", "map": { "key": { "innerKey": { "a": 2, "b": 3 } } } }
+         {"key": "B", "map": { "key": { "innerKey": { "a": 2, "b": 3 } } } }
+         {"key": "C", "map": { "key": { "innerKey": { "a": 3, "b": null } } } }""",
+    expectErrorWithoutEvolutionContains = "Cannot cast")
+
+  testNestedStructsEvolution("source map struct value contains less columns than target")(
+    target =
+      """{ "key": "A", "map": { "key": { "a": 1, "b": 1 } } }
+         { "key": "C", "map": { "key": { "a": 3, "b": 1 } } }""",
+    source =
+      """{ "key": "A", "map": { "key": { "a": 2 } } }
+         { "key": "B", "map": { "key": { "a": 1 } } }""",
+    targetSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", IntegerType))),
+    sourceSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType))),
+    resultSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", IntegerType))),
+    clauses = update("*") :: insert("*") :: Nil,
+    result =
+      """{ "key": "A", "map": { "key": { "a": 2, "b": null } } }
+         { "key": "B", "map": { "key": { "a": 1, "b": null } } }
+         { "key": "C", "map": { "key": { "a": 3, "b": 1 } } }""",
+    expectErrorWithoutEvolutionContains = "Cannot cast")
+
+  testNestedStructsEvolution("source nested map struct value contains less columns than target")(
+    target =
+      """{"key": "A", "map": { "key": { "innerKey": { "a": 1, "b": 1 } } } }
+         {"key": "C", "map": { "key": { "innerKey": { "a": 3, "b": 1 } } } }""",
+    source =
+      """{"key": "A", "map": { "key": { "innerKey": { "a": 2 } } } }
+         {"key": "B", "map": { "key": { "innerKey": { "a": 2 } } } }""",
+    targetSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))),
+    sourceSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          MapType(StringType, new StructType().add("a", IntegerType)))),
+    resultSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))),
+    clauses = update("*") :: insert("*") :: Nil,
+    result =
+      """{"key": "A", "map": { "key": { "innerKey": { "a": 2, "b": null } } } }
+         {"key": "B", "map": { "key": { "innerKey": { "a": 2, "b": null } } } }
+         {"key": "C", "map": { "key": { "innerKey": { "a": 3, "b": 1 } } } }""",
+    expectErrorWithoutEvolutionContains = "Cannot cast")
+
+  testNestedStructsEvolution("source nested map struct value contains different type than target")(
+    target =
+      """{"key": "A", "map": { "key": { "a": 1, "b" : 1 } } }
+         {"key": "C", "map": { "key": { "a": 3, "b" : 1 } } }""",
+    source =
+      """{"key": "A", "map": { "key": { "a": 1, "b" : "2" } } }
+         {"key": "B", "map": { "key": { "a": 2, "b" : "2" } } }""",
+    targetSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", IntegerType))),
+    sourceSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", StringType))),
+    resultSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", IntegerType))),
+    clauses = update("*") :: insert("*") :: Nil,
+    result =
+      """{"key": "A", "map": { "key": { "a": 1, "b" : 2 } } }
+         {"key": "B", "map": { "key": { "a": 2, "b" : 2 } } }
+         {"key": "C", "map": { "key": { "a": 3, "b" : 1 } } }""",
+    resultWithoutEvolution =
+      """{"key": "A", "map": { "key": { "a": 1, "b" : 2 } } }
+         {"key": "B", "map": { "key": { "a": 2, "b" : 2 } } }
+         {"key": "C", "map": { "key": { "a": 3, "b" : 1 } } }""")
+
+  testNestedStructsEvolution("source nested map struct value in different order")(
+    target =
+      """{"key": "A", "map": { "key": { "a" : 1, "b" : 1 } } }
+         {"key": "C", "map": { "key": { "a" : 3, "b" : 1 } } }""",
+    source =
+      """{"key": "A", "map": { "key": { "b" : 2, "a" : 1, "c" : 3 } } }
+         {"key": "B", "map": { "key": { "b" : 2, "a" : 2, "c" : 4 } } }""",
+    targetSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", IntegerType))),
+    sourceSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("b", IntegerType).add("a", IntegerType).add("c", IntegerType))),
+    resultSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType).add("b", IntegerType).add("c", IntegerType))),
+    clauses = update("*") :: insert("*") :: Nil,
+    result =
+      """{"key": "A", "map": { "key": { "a": 1, "b" : 2, "c" : 3 } } }
+         {"key": "B", "map": { "key": { "a": 2, "b" : 2, "c" : 4 } } }
+         {"key": "C", "map": { "key": { "a": 3, "b" : 1, "c" : null } } }""",
+    expectErrorWithoutEvolutionContains = "Cannot cast")
+
+  testNestedStructsEvolution("source map struct value to map array value")(
+    target =
+      """{ "key": "A", "map": { "key": [ 1, 2 ] } }
+         { "key": "C", "map": { "key": [ 3, 4 ] } }""",
+    source =
+      """{ "key": "A", "map": { "key": { "a": 2 } } }
+         { "key": "B", "map": { "key": { "a": 1 } } }""",
+    targetSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          ArrayType(IntegerType))),
+    sourceSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          new StructType().add("a", IntegerType))),
+    clauses = update("*") :: insert("*") :: Nil,
+    expectErrorContains = "Failed to merge incompatible data types",
+    expectErrorWithoutEvolutionContains = "Cannot cast")
+
+  testNestedStructsEvolution("source struct nested in map array values contains more columns in different order")(
+    target =
+      """{ "key": "A", "map": { "key": [ { "a": 1, "b": 2 } ] } }
+         { "key": "C", "map": { "key": [ { "a": 3, "b": 4 } ] } }""",
+    source =
+      """{ "key": "A", "map": { "key": [ { "b": 6, "c": 7, "a": 5 } ] } }
+         { "key": "B", "map": { "key": [ { "b": 9, "c": 10, "a": 8 } ] } }""",
+    targetSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          ArrayType(
+            new StructType().add("a", IntegerType).add("b", IntegerType)))),
+    sourceSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          ArrayType(
+          new StructType().add("b", IntegerType).add("c", IntegerType).add("a", IntegerType)))),
+    resultSchema = new StructType()
+      .add("key", StringType)
+      .add("map", MapType(
+          StringType,
+          ArrayType(
+          new StructType().add("a", IntegerType).add("b", IntegerType).add("c", IntegerType)))),
+    clauses = update("*") :: insert("*") :: Nil,
+    result =
+      """{ "key": "A", "map": { "key": [ { "a": 5, "b": 6, "c": 7 } ] } }
+         { "key": "B", "map": { "key": [ { "a": 8, "b": 9, "c": 10 } ] } }
+         { "key": "C", "map": { "key": [ { "a": 3, "b": 4, "c": null } ] } }""",
+    expectErrorWithoutEvolutionContains = "Cannot cast")
+
+  // Struct evolution inside of map keys.
+  testEvolution("new source column in map struct key")(
+    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
+    sourceData = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2)).toDF("key", "a", "b", "c", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), value) as x"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2), (3, 5, 6, null, 7))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "c", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), value) as x"),
+    expectErrorWithoutEvolutionContains = "Cannot cast"
+  )
+
+  testEvolution("source nested map struct key contains less columns than target")(
+    targetData = Seq((1, 2, 3, 4, 5), (3, 6, 7, 8, 9)).toDF("key", "a", "b", "c", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), value) as x"),
+    sourceData = Seq((1, 10, 50, 1), (2, 20, 60, 2)).toDF("key", "a", "c", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'c', c), value) as x"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = Seq((1, 10, null, 50, 1), (2, 20, null, 60, 2), (3, 6, 7, 8, 9))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "c", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), value) as x"),
+    expectErrorWithoutEvolutionContains = "Cannot cast"
+  )
+
+  testEvolution("source nested map struct key contains different type than target")(
+    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
+    sourceData = Seq((1, 10, "30", 1), (2, 20, "40", 2)).toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
+    expectedWithoutEvolution = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x")
+  )
+
+  testEvolution("source nested map struct key in different order")(
+    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
+    sourceData = Seq((1, 10, 30, 1), (2, 20, 40, 2)).toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('b', b, 'a', a), value) as x"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
+    expectedWithoutEvolution = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x")
+  )
+
+  testEvolution("struct nested in map array keys contains more columns")(
+    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(array(named_struct('a', a, 'b', b)), value) as x"),
+    sourceData = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2)).toDF("key", "a", "b", "c", "value")
+      .selectExpr("key", "map(array(named_struct('a', a, 'b', b, 'c', c)), value) as x"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2), (3, 5, 6, null, 7))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "c", "value")
+      .selectExpr("key", "map(array(named_struct('a', a, 'b', b, 'c', c)), value) as x"),
+    expectErrorWithoutEvolutionContains = "cannot cast"
+  )
+
+  testEvolution("update-only struct nested in map array keys contains more columns")(
+    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
+      .selectExpr("key", "map(array(named_struct('a', a, 'b', b)), value) as x"),
+    sourceData = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2)).toDF("key", "a", "b", "c", "value")
+      .selectExpr("key", "map(array(named_struct('a', a, 'b', b, 'c', c)), value) as x"),
+    clauses = update("*") :: Nil,
+    expected = Seq((1, 10, 30, 50, 1), (3, 5, 6, null, 7))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "c", "value")
+      .selectExpr("key", "map(array(named_struct('a', a, 'b', b, 'c', c)), value) as x"),
+    expectErrorWithoutEvolutionContains = "cannot cast"
+  )
+
+  testEvolution("struct evolution in both map keys and values")(
+    targetData = Seq((1, 2, 3, 4, 5), (3, 6, 7, 8, 9)).toDF("key", "a", "b", "d", "e")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), named_struct('d', d, 'e', e)) as x"),
+    sourceData = Seq((1, 10, 30, 50, 70, 90, 110), (2, 20, 40, 60, 80, 100, 120))
+      .toDF("key", "a", "b", "c", "d", "e", "f")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), named_struct('d', d, 'e', e, 'f', f)) as x"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = Seq((1, 10, 30, 50, 70, 90, 110), (2, 20, 40, 60, 80, 100, 120), (3, 6, 7, null, 8, 9, null))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "c", "d", "e", "f")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), named_struct('d', d, 'e', e, 'f', f)) as x"),
+    expectErrorWithoutEvolutionContains = "cannot cast"
+  )
+
+  testEvolution("update only struct evolution in both map keys and values")(
+    targetData = Seq((1, 2, 3, 4, 5), (3, 6, 7, 8, 9)).toDF("key", "a", "b", "d", "e")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b), named_struct('d', d, 'e', e)) as x"),
+    sourceData = Seq((1, 10, 30, 50, 70, 90, 110), (2, 20, 40, 60, 80, 100, 120))
+      .toDF("key", "a", "b", "c", "d", "e", "f")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), named_struct('d', d, 'e', e, 'f', f)) as x"),
+    clauses = update("*") :: Nil,
+    expected = Seq((1, 10, 30, 50, 70, 90, 110), (3, 6, 7, null, 8, 9, null))
+      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer, Integer, Integer)]]
+      .toDF("key", "a", "b", "c", "d", "e", "f")
+      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), named_struct('d', d, 'e', e, 'f', f)) as x"),
+    expectErrorWithoutEvolutionContains = "cannot cast"
+  )
+  // scalastyle:on line.size.limit
+}
+
+trait MergeIntoNestedStructEvolutionTests extends MergeIntoSchemaEvolutionMixin {
+  self: MergeIntoTestUtils with SharedSparkSession =>
+
+  import testImplicits._
 
   // Nested Schema evolution with UPDATE alone
   testNestedStructsEvolution("new nested source field not in update is ignored")(
@@ -1646,349 +1892,6 @@ trait MergeIntoNestedStructEvolutionTests extends MergeIntoSchemaEvolutionMixin 
           { "key": "B", "value": [ { "a": { "y": 60, "x": [ { "c": 20, "d": 50, "e": null } ] }, "b": 3 } ] }""",
     expectErrorWithoutEvolutionContains = "Cannot cast")
 
-  // Struct evolution inside of map values.
-  testNestedStructsEvolution("new source column in map struct value")(
-    target =
-      """{ "key": "A", "map": { "key": { "a": 1 } } }
-         { "key": "C", "map": { "key": { "a": 3 } } }""",
-    source =
-      """{ "key": "A", "map": { "key": { "a": 2, "b": 2 } } }
-         { "key": "B", "map": { "key": { "a": 1, "b": 2 } } }""",
-    targetSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType))),
-    sourceSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType))),
-    resultSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType))),
-    clauses = update("*") :: insert("*") :: Nil,
-    result =
-      """{ "key": "A", "map": { "key": { "a": 2, "b": 2 } } }
-         { "key": "B", "map": { "key": { "a": 1, "b": 2 } } }
-         { "key": "C", "map": { "key": { "a": 3, "b": null } } }""",
-    expectErrorWithoutEvolutionContains = "Cannot cast")
-
-  testNestedStructsEvolution("new source column in nested map struct value")(
-    target =
-      """{"key": "A", "map": { "key": { "innerKey": { "a": 1 } } } }
-         {"key": "C", "map": { "key": { "innerKey": { "a": 3 } } } }""",
-    source =
-      """{"key": "A", "map": { "key": { "innerKey": { "a": 2, "b": 3 } } } }
-         {"key": "B", "map": { "key": { "innerKey": { "a": 2, "b": 3 } } } }""",
-    targetSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          MapType(StringType, new StructType().add("a", IntegerType)))),
-    sourceSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))),
-    resultSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))),
-    clauses = update("*") :: insert("*") :: Nil,
-    result =
-      """{"key": "A", "map": { "key": { "innerKey": { "a": 2, "b": 3 } } } }
-         {"key": "B", "map": { "key": { "innerKey": { "a": 2, "b": 3 } } } }
-         {"key": "C", "map": { "key": { "innerKey": { "a": 3, "b": null } } } }""",
-    expectErrorWithoutEvolutionContains = "Cannot cast")
-
-  testNestedStructsEvolution("source map struct value contains less columns than target")(
-    target =
-      """{ "key": "A", "map": { "key": { "a": 1, "b": 1 } } }
-         { "key": "C", "map": { "key": { "a": 3, "b": 1 } } }""",
-    source =
-      """{ "key": "A", "map": { "key": { "a": 2 } } }
-         { "key": "B", "map": { "key": { "a": 1 } } }""",
-    targetSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType))),
-    sourceSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType))),
-    resultSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType))),
-    clauses = update("*") :: insert("*") :: Nil,
-    result =
-      """{ "key": "A", "map": { "key": { "a": 2, "b": null } } }
-         { "key": "B", "map": { "key": { "a": 1, "b": null } } }
-         { "key": "C", "map": { "key": { "a": 3, "b": 1 } } }""",
-    expectErrorWithoutEvolutionContains = "Cannot cast")
-
-  testNestedStructsEvolution("source nested map struct value contains less columns than target")(
-    target =
-      """{"key": "A", "map": { "key": { "innerKey": { "a": 1, "b": 1 } } } }
-         {"key": "C", "map": { "key": { "innerKey": { "a": 3, "b": 1 } } } }""",
-    source =
-      """{"key": "A", "map": { "key": { "innerKey": { "a": 2 } } } }
-         {"key": "B", "map": { "key": { "innerKey": { "a": 2 } } } }""",
-    targetSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))),
-    sourceSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          MapType(StringType, new StructType().add("a", IntegerType)))),
-    resultSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))),
-    clauses = update("*") :: insert("*") :: Nil,
-    result =
-      """{"key": "A", "map": { "key": { "innerKey": { "a": 2, "b": null } } } }
-         {"key": "B", "map": { "key": { "innerKey": { "a": 2, "b": null } } } }
-         {"key": "C", "map": { "key": { "innerKey": { "a": 3, "b": 1 } } } }""",
-    expectErrorWithoutEvolutionContains = "Cannot cast")
-
-  testNestedStructsEvolution("source nested map struct value contains different type than target")(
-    target =
-      """{"key": "A", "map": { "key": { "a": 1, "b" : 1 } } }
-         {"key": "C", "map": { "key": { "a": 3, "b" : 1 } } }""",
-    source =
-      """{"key": "A", "map": { "key": { "a": 1, "b" : "2" } } }
-         {"key": "B", "map": { "key": { "a": 2, "b" : "2" } } }""",
-    targetSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType))),
-    sourceSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", StringType))),
-    resultSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType))),
-    clauses = update("*") :: insert("*") :: Nil,
-    result =
-      """{"key": "A", "map": { "key": { "a": 1, "b" : 2 } } }
-         {"key": "B", "map": { "key": { "a": 2, "b" : 2 } } }
-         {"key": "C", "map": { "key": { "a": 3, "b" : 1 } } }""",
-    resultWithoutEvolution =
-      """{"key": "A", "map": { "key": { "a": 1, "b" : 2 } } }
-         {"key": "B", "map": { "key": { "a": 2, "b" : 2 } } }
-         {"key": "C", "map": { "key": { "a": 3, "b" : 1 } } }""")
-
-  testNestedStructsEvolution("source nested map struct value in different order")(
-    target =
-      """{"key": "A", "map": { "key": { "a" : 1, "b" : 1 } } }
-         {"key": "C", "map": { "key": { "a" : 3, "b" : 1 } } }""",
-    source =
-      """{"key": "A", "map": { "key": { "b" : 2, "a" : 1, "c" : 3 } } }
-         {"key": "B", "map": { "key": { "b" : 2, "a" : 2, "c" : 4 } } }""",
-    targetSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType))),
-    sourceSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("b", IntegerType).add("a", IntegerType).add("c", IntegerType))),
-    resultSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType).add("c", IntegerType))),
-    clauses = update("*") :: insert("*") :: Nil,
-    result =
-      """{"key": "A", "map": { "key": { "a": 1, "b" : 2, "c" : 3 } } }
-         {"key": "B", "map": { "key": { "a": 2, "b" : 2, "c" : 4 } } }
-         {"key": "C", "map": { "key": { "a": 3, "b" : 1, "c" : null } } }""",
-    expectErrorWithoutEvolutionContains = "Cannot cast")
-
-  testNestedStructsEvolution("source map struct value to map array value")(
-    target =
-      """{ "key": "A", "map": { "key": [ 1, 2 ] } }
-         { "key": "C", "map": { "key": [ 3, 4 ] } }""",
-    source =
-      """{ "key": "A", "map": { "key": { "a": 2 } } }
-         { "key": "B", "map": { "key": { "a": 1 } } }""",
-    targetSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          ArrayType(IntegerType))),
-    sourceSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          new StructType().add("a", IntegerType))),
-    clauses = update("*") :: insert("*") :: Nil,
-    expectErrorContains = "Failed to merge incompatible data types",
-    expectErrorWithoutEvolutionContains = "Cannot cast")
-
-  testNestedStructsEvolution("source struct nested in map array values contains more columns in different order")(
-    target =
-      """{ "key": "A", "map": { "key": [ { "a": 1, "b": 2 } ] } }
-         { "key": "C", "map": { "key": [ { "a": 3, "b": 4 } ] } }""",
-    source =
-      """{ "key": "A", "map": { "key": [ { "b": 6, "c": 7, "a": 5 } ] } }
-         { "key": "B", "map": { "key": [ { "b": 9, "c": 10, "a": 8 } ] } }""",
-    targetSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          ArrayType(
-            new StructType().add("a", IntegerType).add("b", IntegerType)))),
-    sourceSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          ArrayType(
-          new StructType().add("b", IntegerType).add("c", IntegerType).add("a", IntegerType)))),
-    resultSchema = new StructType()
-      .add("key", StringType)
-      .add("map", MapType(
-          StringType,
-          ArrayType(
-          new StructType().add("a", IntegerType).add("b", IntegerType).add("c", IntegerType)))),
-    clauses = update("*") :: insert("*") :: Nil,
-    result =
-      """{ "key": "A", "map": { "key": [ { "a": 5, "b": 6, "c": 7 } ] } }
-         { "key": "B", "map": { "key": [ { "a": 8, "b": 9, "c": 10 } ] } }
-         { "key": "C", "map": { "key": [ { "a": 3, "b": 4, "c": null } ] } }""",
-    expectErrorWithoutEvolutionContains = "Cannot cast")
-
-  // Struct evolution inside of map keys.
-  testEvolution("new source column in map struct key")(
-    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
-    sourceData = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2)).toDF("key", "a", "b", "c", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), value) as x"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2), (3, 5, 6, null, 7))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "c", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), value) as x"),
-    expectErrorWithoutEvolutionContains = "Cannot cast"
-  )
-
-  testEvolution("source nested map struct key contains less columns than target")(
-    targetData = Seq((1, 2, 3, 4, 5), (3, 6, 7, 8, 9)).toDF("key", "a", "b", "c", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), value) as x"),
-    sourceData = Seq((1, 10, 50, 1), (2, 20, 60, 2)).toDF("key", "a", "c", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'c', c), value) as x"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected = Seq((1, 10, null, 50, 1), (2, 20, null, 60, 2), (3, 6, 7, 8, 9))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "c", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), value) as x"),
-    expectErrorWithoutEvolutionContains = "Cannot cast"
-  )
-
-  testEvolution("source nested map struct key contains different type than target")(
-    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
-    sourceData = Seq((1, 10, "30", 1), (2, 20, "40", 2)).toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
-    expectedWithoutEvolution = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x")
-  )
-
-  testEvolution("source nested map struct key in different order")(
-    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
-    sourceData = Seq((1, 10, 30, 1), (2, 20, 40, 2)).toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('b', b, 'a', a), value) as x"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
-    expectedWithoutEvolution = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x")
-  )
-
-  testEvolution("struct nested in map array keys contains more columns")(
-    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(array(named_struct('a', a, 'b', b)), value) as x"),
-    sourceData = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2)).toDF("key", "a", "b", "c", "value")
-      .selectExpr("key", "map(array(named_struct('a', a, 'b', b, 'c', c)), value) as x"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2), (3, 5, 6, null, 7))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "c", "value")
-      .selectExpr("key", "map(array(named_struct('a', a, 'b', b, 'c', c)), value) as x"),
-    expectErrorWithoutEvolutionContains = "cannot cast"
-  )
-
-  testEvolution("update-only struct nested in map array keys contains more columns")(
-    targetData = Seq((1, 2, 3, 4), (3, 5, 6, 7)).toDF("key", "a", "b", "value")
-      .selectExpr("key", "map(array(named_struct('a', a, 'b', b)), value) as x"),
-    sourceData = Seq((1, 10, 30, 50, 1), (2, 20, 40, 60, 2)).toDF("key", "a", "b", "c", "value")
-      .selectExpr("key", "map(array(named_struct('a', a, 'b', b, 'c', c)), value) as x"),
-    clauses = update("*") :: Nil,
-    expected = Seq((1, 10, 30, 50, 1), (3, 5, 6, null, 7))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "c", "value")
-      .selectExpr("key", "map(array(named_struct('a', a, 'b', b, 'c', c)), value) as x"),
-    expectErrorWithoutEvolutionContains = "cannot cast"
-  )
-
-  testEvolution("struct evolution in both map keys and values")(
-    targetData = Seq((1, 2, 3, 4, 5), (3, 6, 7, 8, 9)).toDF("key", "a", "b", "d", "e")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), named_struct('d', d, 'e', e)) as x"),
-    sourceData = Seq((1, 10, 30, 50, 70, 90, 110), (2, 20, 40, 60, 80, 100, 120))
-      .toDF("key", "a", "b", "c", "d", "e", "f")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), named_struct('d', d, 'e', e, 'f', f)) as x"),
-    clauses = update("*") :: insert("*") :: Nil,
-    expected = Seq((1, 10, 30, 50, 70, 90, 110), (2, 20, 40, 60, 80, 100, 120), (3, 6, 7, null, 8, 9, null))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "c", "d", "e", "f")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), named_struct('d', d, 'e', e, 'f', f)) as x"),
-    expectErrorWithoutEvolutionContains = "cannot cast"
-  )
-
-  testEvolution("update only struct evolution in both map keys and values")(
-    targetData = Seq((1, 2, 3, 4, 5), (3, 6, 7, 8, 9)).toDF("key", "a", "b", "d", "e")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b), named_struct('d', d, 'e', e)) as x"),
-    sourceData = Seq((1, 10, 30, 50, 70, 90, 110), (2, 20, 40, 60, 80, 100, 120))
-      .toDF("key", "a", "b", "c", "d", "e", "f")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), named_struct('d', d, 'e', e, 'f', f)) as x"),
-    clauses = update("*") :: Nil,
-    expected = Seq((1, 10, 30, 50, 70, 90, 110), (3, 6, 7, null, 8, 9, null))
-      .asInstanceOf[List[(Integer, Integer, Integer, Integer, Integer, Integer, Integer)]]
-      .toDF("key", "a", "b", "c", "d", "e", "f")
-      .selectExpr("key", "map(named_struct('a', a, 'b', b, 'c', c), named_struct('d', d, 'e', e, 'f', f)) as x"),
-    expectErrorWithoutEvolutionContains = "cannot cast"
-  )
   // scalastyle:on line.size.limit
 
   // Note that the obvious dual of this test, "update * and insert non-*", doesn't exist
@@ -3298,4 +3201,116 @@ trait MergeIntoNestedStructEvolutionTests extends MergeIntoSchemaEvolutionMixin 
     confs = Seq(
       DeltaSQLConf.DELTA_MERGE_SCHEMA_EVOLUTION_FIX_NESTED_STRUCT_ALIGNMENT.key -> "true")
   )
+
+  testNestedStructsEvolution("nested field assignment qualified with source alias")(
+    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
+    source = Seq("""{ "a": 3, "t": { "a": 5 } }"""),
+    targetSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    sourceSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    cond = "1 = 1",
+    clauses = update("s.t.a = s.t.a") :: Nil,
+    // Assigning to the source is just wrong and should fail.
+    result = Seq("""{ "a": 1, "t": { "a": 5 } }"""),
+    resultSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    expectErrorWithoutEvolutionContains = "cannot resolve s.t.a in UPDATE")
+
+  testNestedStructsEvolution("existing top-level column assignment qualified with target alias")(
+    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
+    source = Seq("""{ "a": 3, "t": { "a": 5 } }"""),
+    targetSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    sourceSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    cond = "1 = 1",
+    // This succeeds and updates 'a': the fully qualified column name 't.a' gets precedence over
+    // the unqualified struct field name '(t.)t.a' to resolve the ambiguity.
+    clauses = update("t.a = s.a") :: Nil,
+    result = Seq("""{ "a": 3, "t": { "a": 2 } }"""),
+    resultSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    resultWithoutEvolution = Seq("""{ "a": 3, "t": { "a": 2 } }"""))
+
+  testNestedStructsEvolution("existing nested field assignment qualified with target alias")(
+    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
+    source = Seq("""{ "a": 3, "t": { "a": 5 } }"""),
+    targetSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    sourceSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    cond = "1 = 1",
+    // This is unambiguous: and resolves to the struct field 't.t.a' during resolution
+    clauses = update("t.t.a = s.t.a") :: Nil,
+    result = Seq("""{ "a": 1, "t": { "a": 5 } }"""),
+    resultSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    resultWithoutEvolution = Seq("""{ "a": 1, "t": { "a": 5 } }"""))
+
+  testNestedStructsEvolution("new top-level column assignment qualified with target alias")(
+    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
+    source = Seq("""{ "a": 3, "b": 4, "t": { "a": 5, "b": 6 } }"""),
+    targetSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    sourceSchema = new StructType()
+      .add("a", IntegerType)
+      .add("b", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)
+        .add("b", IntegerType)),
+    cond = "1 = 1",
+    clauses = update("t.b = s.b") :: Nil,
+    result = Seq("""{ "a": 1, "t": { "a": 2, "b": 4 } }"""),
+    resultSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)
+        .add("b", IntegerType)),
+    expectErrorWithoutEvolutionContains = "No such struct field `b` in `a`")
+
+  testNestedStructsEvolution("new nested field assignment qualified with target alias")(
+    target = Seq("""{ "a": 1, "t": { "a": 2 } }"""),
+    source = Seq("""{ "a": 3, "b": 4, "t": { "a": 5, "b": 6 } }"""),
+    targetSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)),
+    sourceSchema = new StructType()
+      .add("a", IntegerType)
+      .add("b", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)
+        .add("b", IntegerType)),
+    cond = "1 = 1",
+    clauses = update("t.t.b = s.t.b") :: Nil,
+    // t.t.b gets resolved to source struct t, accessing nested field t.t.b which doesn't exist.
+    expectErrorContains = "No such struct field `t` in `a`, `b`",
+    resultSchema = new StructType()
+      .add("a", IntegerType)
+      .add("t", new StructType()
+        .add("a", IntegerType)
+        .add("b", IntegerType)),
+    // t.t.b: t.t gets resolved to target t with nested field b which doesn't exist in fields (a)
+    expectErrorWithoutEvolutionContains = "No such struct field `b` in `a`")
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -160,10 +160,6 @@ trait MergeIntoSuiteBaseMixin
     }
   }
 
-  protected implicit def strToJsonSeq(str: String): Seq[String] = {
-    str.split("\n").filter(_.trim.length > 0)
-  }
-
   protected def insertOnlyMergeFeatureFlagOff(sourceName: String, targetName: String): Unit = {
     executeMerge(
       tgt = s"$targetName t",
@@ -1909,6 +1905,494 @@ trait MergeIntoUnlimitedMergeClausesTests extends MergeIntoSuiteBaseMixin {
     expectedMessageParameters = Map.empty)
 }
 
+trait MergeIntoAnalysisExceptionTests extends MergeIntoSuiteBaseMixin {
+  testMergeAnalysisException("update condition - ambiguous reference")(
+    mergeOn = "s.key = t.key",
+    update(condition = "key > 1", set = "tgtValue = srcValue"))(
+    expectedErrorClass = "AMBIGUOUS_REFERENCE",
+    expectedMessageParameters = Map(
+      "name" -> "`key`",
+      "referenceNames" -> "[`s`.`key`, `t`.`key`]"))
+
+  testMergeAnalysisException("update condition - unknown reference")(
+    mergeOn = "s.key = t.key",
+    update(condition = "unknownAttrib > 1", set = "tgtValue = srcValue"))(
+    // Should show unknownAttrib as invalid ref and (key, tgtValue, srcValue) as valid column names.
+    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
+    expectedMessageParameters = Map(
+      "sqlExpr" -> "unknownAttrib",
+      "clause" -> "UPDATE condition",
+      "cols" -> "t.key, t.tgtValue, s.key, s.srcValue"))
+
+  testMergeAnalysisException("update condition - aggregation function")(
+    mergeOn = "s.key = t.key",
+    update(condition = "max(0) > 0", set = "tgtValue = srcValue"))(
+    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
+    expectedMessageParameters = Map(
+      "operation" -> "UPDATE condition of MERGE operation",
+      "predicate" -> "(condition = (max(0) > 0))"))
+
+  testMergeAnalysisException("update condition - subquery")(
+    mergeOn = "s.key = t.key",
+    update(condition = "s.srcValue in (select value from t)", set = "tgtValue = srcValue"))(
+    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
+    expectedMessageParameters = Map("relationName" -> "`t`"))
+
+  testMergeAnalysisException("delete condition - ambiguous reference")(
+    mergeOn = "s.key = t.key",
+    delete(condition = "key > 1"))(
+    expectedErrorClass = "AMBIGUOUS_REFERENCE",
+    expectedMessageParameters = Map(
+      "name" -> "`key`",
+      "referenceNames" -> "[`s`.`key`, `t`.`key`]"))
+
+  testMergeAnalysisException("delete condition - unknown reference")(
+    mergeOn = "s.key = t.key",
+    delete(condition = "unknownAttrib > 1"))(
+    // Should show unknownAttrib as invalid ref and (key, tgtValue, srcValue) as valid column names.
+    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
+    expectedMessageParameters = Map(
+      "sqlExpr" -> "unknownAttrib",
+      "clause" -> "DELETE condition",
+      "cols" -> "t.key, t.tgtValue, s.key, s.srcValue"))
+
+  testMergeAnalysisException("delete condition - aggregation function")(
+    mergeOn = "s.key = t.key",
+    delete(condition = "max(0) > 0"))(
+    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
+    expectedMessageParameters = Map(
+      "operation" -> "DELETE condition of MERGE operation",
+      "predicate" -> "(condition = (max(0) > 0))"))
+
+  testMergeAnalysisException("delete condition - subquery")(
+    mergeOn = "s.key = t.key",
+    delete(condition = "s.srcValue in (select tgtValue from t)"))(
+    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
+    expectedMessageParameters = Map("relationName" -> "`t`"))
+
+  testMergeAnalysisException("insert condition - unknown reference")(
+    mergeOn = "s.key = t.key",
+    insert(condition = "unknownAttrib > 1", values = "(key, tgtValue) VALUES (s.key, s.srcValue)"))(
+    // Should show unknownAttrib as invalid ref and (key, srcValue) as valid column names,
+    // but not show tgtValue as a valid name as target columns cannot be present in insert clause.
+    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
+    expectedMessageParameters = Map(
+      "sqlExpr" -> "unknownAttrib",
+      "clause" -> "INSERT condition",
+      "cols" -> "s.key, s.srcValue"))
+
+  testMergeAnalysisException("insert condition - reference to target table column")(
+    mergeOn = "s.key = t.key",
+    insert(condition = "tgtValue > 1", values = "(key, tgtValue) VALUES (s.key, s.srcValue)"))(
+    // Should show tgtValue as invalid ref and (key, srcValue) as valid column names
+    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
+    expectedMessageParameters = Map(
+      "sqlExpr" -> "tgtValue",
+      "clause" -> "INSERT condition",
+      "cols" -> "s.key, s.srcValue"))
+
+  testMergeAnalysisException("insert condition - aggregation function")(
+    mergeOn = "s.key = t.key",
+    insert(condition = "max(0) > 0", values = "(key, tgtValue) VALUES (s.key, s.srcValue)"))(
+    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
+    expectedMessageParameters = Map(
+      "operation" -> "INSERT condition of MERGE operation",
+      "predicate" -> "(condition = (max(0) > 0))"))
+
+  testMergeAnalysisException("insert condition - subquery")(
+    mergeOn = "s.key = t.key",
+    insert(
+      condition = "s.srcValue in (select srcValue from s)",
+      values = "(key, tgtValue) VALUES (s.key, s.srcValue)"))(
+    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
+    expectedMessageParameters = Map("relationName" -> "`s`"))
+}
+
+trait MergeIntoExtendedSyntaxTests extends MergeIntoSuiteBaseMixin {
+  import testImplicits._
+
+  private def testMergeErrorOnMultipleMatches(
+      name: String,
+      confs: Seq[(String, String)] = Seq.empty)(
+      source: Seq[(Int, Int)],
+      target: Seq[(Int, Int)],
+      mergeOn: String,
+      mergeClauses: MergeClause*): Unit = {
+    test(s"extended syntax - $name") {
+      withSQLConf(confs: _*) {
+        withKeyValueData(source, target) { case (sourceName, targetName) =>
+          val docURL = "/delta-update.html#upsert-into-a-table-using-merge"
+
+          checkError(
+            exception = intercept[DeltaUnsupportedOperationException] {
+              executeMerge(s"$targetName t", s"$sourceName s", mergeOn, mergeClauses: _*)
+            },
+            "DELTA_MULTIPLE_SOURCE_ROW_MATCHING_TARGET_ROW_IN_MERGE",
+            parameters = Map(
+              "usageReference" -> DeltaErrors.generateDocsLink(
+                spark.sparkContext.getConf, docURL, skipValidation = true))
+          )
+        }
+      }
+    }
+  }
+
+  testExtendedMerge("only update")(
+    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2)  :: Nil,
+    mergeOn = "s.key = t.key",
+    update(set = "key = s.key, value = s.value"))(
+    result = Seq(
+      (1, 10),  // (1, 1) updated
+      (2, 2)
+    ))
+
+  testMergeErrorOnMultipleMatches("only update with multiple matches")(
+    source = (0, 0) :: (1, 10) :: (1, 11) :: (2, 20) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(set = "key = s.key, value = s.value"))
+
+  testExtendedMerge("only conditional update")(
+    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: (3, 3) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.value <> 20 AND t.value <> 3", set = "key = s.key, value = s.value"))(
+    result = Seq(
+      (1, 10),  // updated
+      (2, 2),   // not updated due to source-only condition `s.value <> 20`
+      (3, 3)    // not updated due to target-only condition `t.value <> 3`
+    ))
+
+  testMergeErrorOnMultipleMatches("only conditional update with multiple matches")(
+    source = (0, 0) :: (1, 10) :: (1, 11) :: (2, 20) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.value = 10", set = "key = s.key, value = s.value"))
+
+  testExtendedMerge("only delete")(
+    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    delete())(
+    result = Seq(
+      (2, 2)    // (1, 1) deleted
+    ))          // (3, 30) not inserted as not insert clause
+
+  // This is not ambiguous even when there are multiple matches
+  testExtendedMerge(s"only delete with multiple matches")(
+    source = (0, 0) :: (1, 10) :: (1, 100) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    delete())(
+    result = Seq(
+      (2, 2)  // (1, 1) matches multiple source rows but unambiguously deleted
+    )
+  )
+
+  testExtendedMerge("only conditional delete")(
+    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: (3, 3) :: Nil,
+    mergeOn = "s.key = t.key",
+    delete(condition = "s.value <> 20 AND t.value <> 3"))(
+    result = Seq(
+      (2, 2),   // not deleted due to source-only condition `s.value <> 20`
+      (3, 3)    // not deleted due to target-only condition `t.value <> 3`
+    ))          // (1, 1) deleted
+
+  testMergeErrorOnMultipleMatches("only conditional delete with multiple matches")(
+    source = (0, 0) :: (1, 10) :: (1, 100) :: (2, 20) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    delete(condition = "s.value = 10"))
+
+  testExtendedMerge("conditional update + delete")(
+    source = (0, 0) :: (1, 10) :: (2, 20) :: Nil,
+    target = (1, 1) :: (2, 2) :: (3, 3) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.key <> 1", set = "key = s.key, value = s.value"),
+    delete())(
+    result = Seq(
+      (2, 20),  // (2, 2) updated, (1, 1) deleted as it did not match update condition
+      (3, 3)
+    ))
+
+  testMergeErrorOnMultipleMatches("conditional update + delete with multiple matches")(
+    source = (0, 0) :: (1, 10) :: (2, 20) :: (2, 200) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.value = 20", set = "key = s.key, value = s.value"),
+    delete())
+
+  testExtendedMerge("conditional update + conditional delete")(
+    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: (3, 3) :: (4, 4) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.key <> 1", set = "key = s.key, value = s.value"),
+    delete(condition = "s.key <> 2"))(
+    result = Seq(
+      (2, 20),  // (2, 2) updated as it matched update condition
+      (3, 30),  // (3, 3) updated even though it matched update and delete conditions, as update 1st
+      (4, 4)
+    ))          // (1, 1) deleted as it matched delete condition
+
+  testMergeErrorOnMultipleMatches(
+    "conditional update + conditional delete with multiple matches")(
+    source = (0, 0) :: (1, 10) :: (1, 100) :: (2, 20) :: (2, 200) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.value = 20", set = "key = s.key, value = s.value"),
+    delete(condition = "s.value = 10"))
+
+  testExtendedMerge("conditional delete + conditional update (order matters)")(
+    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: (3, 3) :: (4, 4) :: Nil,
+    mergeOn = "s.key = t.key",
+    delete(condition = "s.key <> 2"),
+    update(condition = "s.key <> 1", set = "key = s.key, value = s.value"))(
+    result = Seq(
+      (2, 20),  // (2, 2) updated as it matched update condition
+      (4, 4)    // (4, 4) unchanged
+    ))          // (1, 1) and (3, 3) deleted as they matched delete condition (before update cond)
+
+  testExtendedMerge("only insert")(
+    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    insert(values = "(key, value) VALUES (s.key, s.value)"))(
+    result = Seq(
+      (0, 0),   // (0, 0) inserted
+      (1, 1),   // (1, 1) not updated as no update clause
+      (2, 2),   // (2, 2) not updated as no update clause
+      (3, 30)   // (3, 30) inserted
+    ))
+
+  testExtendedMerge("only conditional insert")(
+    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    insert(condition = "s.value <> 30", values = "(key, value) VALUES (s.key, s.value)"))(
+    result = Seq(
+      (0, 0),   // (0, 0) inserted by condition but not (3, 30)
+      (1, 1),
+      (2, 2)
+    ))
+
+  testExtendedMerge("update + conditional insert")(
+    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    update("key = s.key, value = s.value"),
+    insert(condition = "s.value <> 30", values = "(key, value) VALUES (s.key, s.value)"))(
+    result = Seq(
+      (0, 0),   // (0, 0) inserted by condition but not (3, 30)
+      (1, 10),  // (1, 1) updated
+      (2, 2)
+    ))
+
+  testExtendedMerge("conditional update + conditional insert")(
+    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.key > 1", set = "key = s.key, value = s.value"),
+    insert(condition = "s.key > 1", values = "(key, value) VALUES (s.key, s.value)"))(
+    result = Seq(
+      (1, 1),   // (1, 1) not updated by condition
+      (2, 20),  // (2, 2) updated by condition
+      (3, 30)   // (3, 30) inserted by condition but not (0, 0)
+    ))
+
+  // This is specifically to test the MergeIntoDeltaCommand.writeOnlyInserts code paths
+  testExtendedMerge("update + conditional insert clause with data to only insert, no updates")(
+    source = (0, 0) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    update("key = s.key, value = s.value"),
+    insert(condition = "s.value <> 30", values = "(key, value) VALUES (s.key, s.value)"))(
+    result = Seq(
+      (0, 0),   // (0, 0) inserted by condition but not (3, 30)
+      (1, 1),
+      (2, 2)
+    ))
+
+  testExtendedMerge(s"delete + insert with multiple matches for both") (
+    source = (1, 10) :: (1, 100) :: (3, 30) :: (3, 300) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    delete(),
+    insert(values = "(key, value) VALUES (s.key, s.value)")) (
+    result = Seq(
+               // (1, 1) matches multiple source rows but unambiguously deleted
+      (2, 2),  // existed previously
+      (3, 30), // inserted
+      (3, 300) // inserted
+    )
+  )
+
+  testExtendedMerge("conditional update + conditional delete + conditional insert")(
+    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: (4, 40) :: Nil,
+    target = (1, 1) :: (2, 2) :: (3, 3) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.key < 2", set = "key = s.key, value = s.value"),
+    delete(condition = "s.key < 3"),
+    insert(condition = "s.key > 1", values = "(key, value) VALUES (s.key, s.value)"))(
+    result = Seq(
+      (1, 10),  // (1, 1) updated by condition, but not (2, 2) or (3, 3)
+      (3, 3),   // neither updated nor deleted as it matched neither condition
+      (4, 40)   // (4, 40) inserted by condition, but not (0, 0)
+    ))          // (2, 2) deleted by condition but not (1, 1) or (3, 3)
+
+  testMergeErrorOnMultipleMatches(
+    "conditional update + conditional delete + conditional insert with multiple matches")(
+    source = (0, 0) :: (1, 10) :: (1, 100) :: (2, 20) :: (2, 200) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(condition = "s.value = 20", set = "key = s.key, value = s.value"),
+    delete(condition = "s.value = 10"),
+    insert(condition = "s.value = 0", values = "(key, value) VALUES (s.key, s.value)"))
+
+  // complex merge condition = has target-only and source-only predicates
+  testExtendedMerge(
+    "conditional update + conditional delete + conditional insert + complex merge condition ")(
+    source = (-1, -10) :: (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: (4, 40) :: (5, 50) :: Nil,
+    target = (-1, -1) :: (1, 1) :: (2, 2) :: (3, 3) :: (5, 5) :: Nil,
+    mergeOn = "s.key = t.key AND t.value > 0 AND s.key < 5",
+    update(condition = "s.key < 2", set = "key = s.key, value = s.value"),
+    delete(condition = "s.key < 3"),
+    insert(condition = "s.key > 1", values = "(key, value) VALUES (s.key, s.value)"))(
+    result = Seq(
+      (-1, -1), // (-1, -1) not matched with (-1, -10) by target-only condition 't.value > 0', so
+                // not updated, But (-1, -10) not inserted as insert condition is 's.key > 1'
+                // (0, 0) not matched any target but not inserted as insert condition is 's.key > 1'
+      (1, 10),  // (1, 1) matched with (1, 10) and updated as update condition is 's.key < 2'
+                // (2, 2) matched with (2, 20) and deleted as delete condition is 's.key < 3'
+      (3, 3),   // (3, 3) matched with (3, 30) but neither updated nor deleted as it did not
+                // satisfy update or delete condition
+      (4, 40),  // (4, 40) not matched any target, so inserted as insert condition is 's.key > 1'
+      (5, 5),   // (5, 5) not matched with (5, 50) by source-only condition 's.key < 5', no update
+      (5, 50)   // (5, 50) inserted as inserted as insert condition is 's.key > 1'
+    ))
+
+  test("extended syntax - different # cols in source than target") {
+    val sourceData =
+      (0, 0, 0) :: (1, 10, 100) :: (2, 20, 200) :: (3, 30, 300) :: (4, 40, 400) :: Nil
+    val targetData = (1, 1) :: (2, 2) :: (3, 3) :: Nil
+
+    withTempView("source") {
+      append(targetData.toDF("key", "value"), Nil)
+      sourceData.toDF("key", "value", "extra").createOrReplaceTempView("source")
+      executeMerge(
+        s"$tableSQLIdentifier t",
+        "source s",
+        cond = "s.key = t.key",
+        update(condition = "s.key < 2", set = "key = s.key, value = s.value + s.extra"),
+        delete(condition = "s.key < 3"),
+        insert(condition = "s.key > 1", values = "(key, value) VALUES (s.key, s.value + s.extra)"))
+
+      checkAnswer(
+        readDeltaTableByIdentifier(),
+        Seq(
+          Row(1, 110),  // (1, 1) updated by condition, but not (2, 2) or (3, 3)
+          Row(3, 3),    // neither updated nor deleted as it matched neither condition
+          Row(4, 440)   // (4, 40) inserted by condition, but not (0, 0)
+        ))              // (2, 2) deleted by condition but not (1, 1) or (3, 3)
+    }
+  }
+
+  test("extended syntax - nested data - conditions and actions") {
+    withJsonData(
+      source =
+        """{ "key": { "x": "X1", "y": 1}, "value" : { "a": 100, "b": "B100" } }
+          { "key": { "x": "X2", "y": 2}, "value" : { "a": 200, "b": "B200" } }
+          { "key": { "x": "X3", "y": 3}, "value" : { "a": 300, "b": "B300" } }
+          { "key": { "x": "X4", "y": 4}, "value" : { "a": 400, "b": "B400" } }""",
+      target =
+        """{ "key": { "x": "X1", "y": 1}, "value" : { "a": 1,   "b": "B1" } }
+          { "key": { "x": "X2", "y": 2}, "value" : { "a": 2,   "b": "B2" } }"""
+    ) { case (sourceName, targetName) =>
+      executeMerge(
+        s"$targetName t",
+        s"$sourceName s",
+        cond = "s.key = t.key",
+        update(condition = "s.key.y < 2", set = "key = s.key, value = s.value"),
+        insert(condition = "s.key.x < 'X4'", values = "(key, value) VALUES (s.key, s.value)"))
+
+      checkAnswer(
+        readDeltaTableByIdentifier(),
+        spark.read.json(Seq(
+          """{ "key": { "x": "X1", "y": 1}, "value" : { "a": 100, "b": "B100" } }""", // updated
+          """{ "key": { "x": "X2", "y": 2}, "value" : { "a": 2,   "b": "B2"   } }""", // not updated
+          """{ "key": { "x": "X3", "y": 3}, "value" : { "a": 300, "b": "B300" } }"""  // inserted
+        ).toDS))
+    }
+  }
+
+  testExtendedMerge("insert only merge")(
+    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2)  :: Nil,
+    mergeOn = "s.key = t.key",
+    insert(values = "*"))(
+    result = Seq(
+      (0, 0), // inserted
+      (1, 1), // existed previously
+      (2, 2), // existed previously
+      (3, 30) // inserted
+    ))
+
+  testExtendedMerge("insert only merge with insert condition on source")(
+    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2)  :: Nil,
+    mergeOn = "s.key = t.key",
+    insert(values = "*", condition = "s.key = s.value"))(
+    result = Seq(
+      (0, 0), // inserted
+      (1, 1), // existed previously
+      (2, 2)  // existed previously
+    ))
+
+  testExtendedMerge("insert only merge with predicate insert")(
+    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
+    target = (1, 1) :: (2, 2)  :: Nil,
+    mergeOn = "s.key = t.key",
+    insert(values = "(t.key, t.value) VALUES (s.key + 10, s.value + 10)"))(
+    result = Seq(
+      (10, 10), // inserted
+      (1, 1), // existed previously
+      (2, 2), // existed previously
+      (13, 40) // inserted
+    ))
+
+  testExtendedMerge(s"insert only merge with multiple matches") (
+    source = (0, 0) :: (1, 10) :: (1, 100) :: (3, 30) :: (3, 300) :: Nil,
+    target = (1, 1) :: (2, 2) :: Nil,
+    mergeOn = "s.key = t.key",
+    insert(values = "(key, value) VALUES (s.key, s.value)")) (
+    result = Seq(
+      (0, 0), // inserted
+      (1, 1), // existed previously
+      (2, 2), // existed previously
+      (3, 30), // inserted
+      (3, 300) // key exists but still inserted
+    )
+  )
+
+  testMergeErrorOnMultipleMatches(
+    "unconditional insert only merge - multiple matches when feature flag off",
+    confs = Seq(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false"))(
+    source = (1, 10) :: (1, 100) :: (2, 20) :: Nil,
+    target = (1, 1) :: Nil,
+    mergeOn = "s.key = t.key",
+    insert(values = "(key, value) VALUES (s.key, s.value)"))
+
+  testMergeErrorOnMultipleMatches(
+    "conditional insert only merge - multiple matches when feature flag off",
+    confs = Seq(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false"))(
+    source = (1, 10) :: (1, 100) :: (2, 20) :: (2, 200) :: Nil,
+    target = (1, 1) :: Nil,
+    mergeOn = "s.key = t.key",
+    insert(condition = "s.value = 20", values = "(key, value) VALUES (s.key, s.value)"))
+}
+
 trait MergeIntoSuiteBaseMiscTests extends MergeIntoSuiteBaseMixin {
   import testImplicits._
 
@@ -2380,425 +2864,6 @@ trait MergeIntoSuiteBaseMiscTests extends MergeIntoSuiteBaseMixin {
     }
   }
 
-
-  testMergeAnalysisException("update condition - ambiguous reference")(
-    mergeOn = "s.key = t.key",
-    update(condition = "key > 1", set = "tgtValue = srcValue"))(
-    expectedErrorClass = "AMBIGUOUS_REFERENCE",
-    expectedMessageParameters = Map(
-      "name" -> "`key`",
-      "referenceNames" -> "[`s`.`key`, `t`.`key`]"))
-
-  testMergeAnalysisException("update condition - unknown reference")(
-    mergeOn = "s.key = t.key",
-    update(condition = "unknownAttrib > 1", set = "tgtValue = srcValue"))(
-    // Should show unknownAttrib as invalid ref and (key, tgtValue, srcValue) as valid column names.
-    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
-    expectedMessageParameters = Map(
-      "sqlExpr" -> "unknownAttrib",
-      "clause" -> "UPDATE condition",
-      "cols" -> "t.key, t.tgtValue, s.key, s.srcValue"))
-
-  testMergeAnalysisException("update condition - aggregation function")(
-    mergeOn = "s.key = t.key",
-    update(condition = "max(0) > 0", set = "tgtValue = srcValue"))(
-    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
-    expectedMessageParameters = Map(
-      "operation" -> "UPDATE condition of MERGE operation",
-      "predicate" -> "(condition = (max(0) > 0))"))
-
-  testMergeAnalysisException("update condition - subquery")(
-    mergeOn = "s.key = t.key",
-    update(condition = "s.srcValue in (select value from t)", set = "tgtValue = srcValue"))(
-    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
-    expectedMessageParameters = Map("relationName" -> "`t`"))
-
-  testMergeAnalysisException("delete condition - ambiguous reference")(
-    mergeOn = "s.key = t.key",
-    delete(condition = "key > 1"))(
-    expectedErrorClass = "AMBIGUOUS_REFERENCE",
-    expectedMessageParameters = Map(
-      "name" -> "`key`",
-      "referenceNames" -> "[`s`.`key`, `t`.`key`]"))
-
-  testMergeAnalysisException("delete condition - unknown reference")(
-    mergeOn = "s.key = t.key",
-    delete(condition = "unknownAttrib > 1"))(
-    // Should show unknownAttrib as invalid ref and (key, tgtValue, srcValue) as valid column names.
-    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
-    expectedMessageParameters = Map(
-      "sqlExpr" -> "unknownAttrib",
-      "clause" -> "DELETE condition",
-      "cols" -> "t.key, t.tgtValue, s.key, s.srcValue"))
-
-  testMergeAnalysisException("delete condition - aggregation function")(
-    mergeOn = "s.key = t.key",
-    delete(condition = "max(0) > 0"))(
-    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
-    expectedMessageParameters = Map(
-      "operation" -> "DELETE condition of MERGE operation",
-      "predicate" -> "(condition = (max(0) > 0))"))
-
-  testMergeAnalysisException("delete condition - subquery")(
-    mergeOn = "s.key = t.key",
-    delete(condition = "s.srcValue in (select tgtValue from t)"))(
-    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
-    expectedMessageParameters = Map("relationName" -> "`t`"))
-
-  testMergeAnalysisException("insert condition - unknown reference")(
-    mergeOn = "s.key = t.key",
-    insert(condition = "unknownAttrib > 1", values = "(key, tgtValue) VALUES (s.key, s.srcValue)"))(
-    // Should show unknownAttrib as invalid ref and (key, srcValue) as valid column names,
-    // but not show tgtValue as a valid name as target columns cannot be present in insert clause.
-    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
-    expectedMessageParameters = Map(
-      "sqlExpr" -> "unknownAttrib",
-      "clause" -> "INSERT condition",
-      "cols" -> "s.key, s.srcValue"))
-
-  testMergeAnalysisException("insert condition - reference to target table column")(
-    mergeOn = "s.key = t.key",
-    insert(condition = "tgtValue > 1", values = "(key, tgtValue) VALUES (s.key, s.srcValue)"))(
-    // Should show tgtValue as invalid ref and (key, srcValue) as valid column names
-    expectedErrorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
-    expectedMessageParameters = Map(
-      "sqlExpr" -> "tgtValue",
-      "clause" -> "INSERT condition",
-      "cols" -> "s.key, s.srcValue"))
-
-  testMergeAnalysisException("insert condition - aggregation function")(
-    mergeOn = "s.key = t.key",
-    insert(condition = "max(0) > 0", values = "(key, tgtValue) VALUES (s.key, s.srcValue)"))(
-    expectedErrorClass = "DELTA_AGGREGATION_NOT_SUPPORTED",
-    expectedMessageParameters = Map(
-      "operation" -> "INSERT condition of MERGE operation",
-      "predicate" -> "(condition = (max(0) > 0))"))
-
-  testMergeAnalysisException("insert condition - subquery")(
-    mergeOn = "s.key = t.key",
-    insert(
-      condition = "s.srcValue in (select srcValue from s)",
-      values = "(key, tgtValue) VALUES (s.key, s.srcValue)"))(
-    expectedErrorClass = "TABLE_OR_VIEW_NOT_FOUND",
-    expectedMessageParameters = Map("relationName" -> "`s`"))
-
-
-  private def testMergeErrorOnMultipleMatches(
-      name: String,
-      confs: Seq[(String, String)] = Seq.empty)(
-      source: Seq[(Int, Int)],
-      target: Seq[(Int, Int)],
-      mergeOn: String,
-      mergeClauses: MergeClause*): Unit = {
-    test(s"extended syntax - $name") {
-      withSQLConf(confs: _*) {
-        withKeyValueData(source, target) { case (sourceName, targetName) =>
-          val docURL = "/delta-update.html#upsert-into-a-table-using-merge"
-
-          checkError(
-            exception = intercept[DeltaUnsupportedOperationException] {
-              executeMerge(s"$targetName t", s"$sourceName s", mergeOn, mergeClauses: _*)
-            },
-            "DELTA_MULTIPLE_SOURCE_ROW_MATCHING_TARGET_ROW_IN_MERGE",
-            parameters = Map(
-              "usageReference" -> DeltaErrors.generateDocsLink(
-                spark.sparkContext.getConf, docURL, skipValidation = true))
-          )
-        }
-      }
-    }
-  }
-
-  testExtendedMerge("only update")(
-    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2)  :: Nil,
-    mergeOn = "s.key = t.key",
-    update(set = "key = s.key, value = s.value"))(
-    result = Seq(
-      (1, 10),  // (1, 1) updated
-      (2, 2)
-    ))
-
-  testMergeErrorOnMultipleMatches("only update with multiple matches")(
-    source = (0, 0) :: (1, 10) :: (1, 11) :: (2, 20) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(set = "key = s.key, value = s.value"))
-
-  testExtendedMerge("only conditional update")(
-    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: (3, 3) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.value <> 20 AND t.value <> 3", set = "key = s.key, value = s.value"))(
-    result = Seq(
-      (1, 10),  // updated
-      (2, 2),   // not updated due to source-only condition `s.value <> 20`
-      (3, 3)    // not updated due to target-only condition `t.value <> 3`
-    ))
-
-  testMergeErrorOnMultipleMatches("only conditional update with multiple matches")(
-    source = (0, 0) :: (1, 10) :: (1, 11) :: (2, 20) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.value = 10", set = "key = s.key, value = s.value"))
-
-  testExtendedMerge("only delete")(
-    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    delete())(
-    result = Seq(
-      (2, 2)    // (1, 1) deleted
-    ))          // (3, 30) not inserted as not insert clause
-
-  // This is not ambiguous even when there are multiple matches
-  testExtendedMerge(s"only delete with multiple matches")(
-    source = (0, 0) :: (1, 10) :: (1, 100) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    delete())(
-    result = Seq(
-      (2, 2)  // (1, 1) matches multiple source rows but unambiguously deleted
-    )
-  )
-
-  testExtendedMerge("only conditional delete")(
-    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: (3, 3) :: Nil,
-    mergeOn = "s.key = t.key",
-    delete(condition = "s.value <> 20 AND t.value <> 3"))(
-    result = Seq(
-      (2, 2),   // not deleted due to source-only condition `s.value <> 20`
-      (3, 3)    // not deleted due to target-only condition `t.value <> 3`
-    ))          // (1, 1) deleted
-
-  testMergeErrorOnMultipleMatches("only conditional delete with multiple matches")(
-    source = (0, 0) :: (1, 10) :: (1, 100) :: (2, 20) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    delete(condition = "s.value = 10"))
-
-  testExtendedMerge("conditional update + delete")(
-    source = (0, 0) :: (1, 10) :: (2, 20) :: Nil,
-    target = (1, 1) :: (2, 2) :: (3, 3) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.key <> 1", set = "key = s.key, value = s.value"),
-    delete())(
-    result = Seq(
-      (2, 20),  // (2, 2) updated, (1, 1) deleted as it did not match update condition
-      (3, 3)
-    ))
-
-  testMergeErrorOnMultipleMatches("conditional update + delete with multiple matches")(
-    source = (0, 0) :: (1, 10) :: (2, 20) :: (2, 200) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.value = 20", set = "key = s.key, value = s.value"),
-    delete())
-
-  testExtendedMerge("conditional update + conditional delete")(
-    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: (3, 3) :: (4, 4) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.key <> 1", set = "key = s.key, value = s.value"),
-    delete(condition = "s.key <> 2"))(
-    result = Seq(
-      (2, 20),  // (2, 2) updated as it matched update condition
-      (3, 30),  // (3, 3) updated even though it matched update and delete conditions, as update 1st
-      (4, 4)
-    ))          // (1, 1) deleted as it matched delete condition
-
-  testMergeErrorOnMultipleMatches(
-    "conditional update + conditional delete with multiple matches")(
-    source = (0, 0) :: (1, 10) :: (1, 100) :: (2, 20) :: (2, 200) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.value = 20", set = "key = s.key, value = s.value"),
-    delete(condition = "s.value = 10"))
-
-  testExtendedMerge("conditional delete + conditional update (order matters)")(
-    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: (3, 3) :: (4, 4) :: Nil,
-    mergeOn = "s.key = t.key",
-    delete(condition = "s.key <> 2"),
-    update(condition = "s.key <> 1", set = "key = s.key, value = s.value"))(
-    result = Seq(
-      (2, 20),  // (2, 2) updated as it matched update condition
-      (4, 4)    // (4, 4) unchanged
-    ))          // (1, 1) and (3, 3) deleted as they matched delete condition (before update cond)
-
-  testExtendedMerge("only insert")(
-    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    insert(values = "(key, value) VALUES (s.key, s.value)"))(
-    result = Seq(
-      (0, 0),   // (0, 0) inserted
-      (1, 1),   // (1, 1) not updated as no update clause
-      (2, 2),   // (2, 2) not updated as no update clause
-      (3, 30)   // (3, 30) inserted
-    ))
-
-  testExtendedMerge("only conditional insert")(
-    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    insert(condition = "s.value <> 30", values = "(key, value) VALUES (s.key, s.value)"))(
-    result = Seq(
-      (0, 0),   // (0, 0) inserted by condition but not (3, 30)
-      (1, 1),
-      (2, 2)
-    ))
-
-  testExtendedMerge("update + conditional insert")(
-    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    update("key = s.key, value = s.value"),
-    insert(condition = "s.value <> 30", values = "(key, value) VALUES (s.key, s.value)"))(
-    result = Seq(
-      (0, 0),   // (0, 0) inserted by condition but not (3, 30)
-      (1, 10),  // (1, 1) updated
-      (2, 2)
-    ))
-
-  testExtendedMerge("conditional update + conditional insert")(
-    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.key > 1", set = "key = s.key, value = s.value"),
-    insert(condition = "s.key > 1", values = "(key, value) VALUES (s.key, s.value)"))(
-    result = Seq(
-      (1, 1),   // (1, 1) not updated by condition
-      (2, 20),  // (2, 2) updated by condition
-      (3, 30)   // (3, 30) inserted by condition but not (0, 0)
-    ))
-
-  // This is specifically to test the MergeIntoDeltaCommand.writeOnlyInserts code paths
-  testExtendedMerge("update + conditional insert clause with data to only insert, no updates")(
-    source = (0, 0) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    update("key = s.key, value = s.value"),
-    insert(condition = "s.value <> 30", values = "(key, value) VALUES (s.key, s.value)"))(
-    result = Seq(
-      (0, 0),   // (0, 0) inserted by condition but not (3, 30)
-      (1, 1),
-      (2, 2)
-    ))
-
-  testExtendedMerge(s"delete + insert with multiple matches for both") (
-    source = (1, 10) :: (1, 100) :: (3, 30) :: (3, 300) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    delete(),
-    insert(values = "(key, value) VALUES (s.key, s.value)")) (
-    result = Seq(
-               // (1, 1) matches multiple source rows but unambiguously deleted
-      (2, 2),  // existed previously
-      (3, 30), // inserted
-      (3, 300) // inserted
-    )
-  )
-
-  testExtendedMerge("conditional update + conditional delete + conditional insert")(
-    source = (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: (4, 40) :: Nil,
-    target = (1, 1) :: (2, 2) :: (3, 3) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.key < 2", set = "key = s.key, value = s.value"),
-    delete(condition = "s.key < 3"),
-    insert(condition = "s.key > 1", values = "(key, value) VALUES (s.key, s.value)"))(
-    result = Seq(
-      (1, 10),  // (1, 1) updated by condition, but not (2, 2) or (3, 3)
-      (3, 3),   // neither updated nor deleted as it matched neither condition
-      (4, 40)   // (4, 40) inserted by condition, but not (0, 0)
-    ))          // (2, 2) deleted by condition but not (1, 1) or (3, 3)
-
-  testMergeErrorOnMultipleMatches(
-    "conditional update + conditional delete + conditional insert with multiple matches")(
-    source = (0, 0) :: (1, 10) :: (1, 100) :: (2, 20) :: (2, 200) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    update(condition = "s.value = 20", set = "key = s.key, value = s.value"),
-    delete(condition = "s.value = 10"),
-    insert(condition = "s.value = 0", values = "(key, value) VALUES (s.key, s.value)"))
-
-  // complex merge condition = has target-only and source-only predicates
-  testExtendedMerge(
-    "conditional update + conditional delete + conditional insert + complex merge condition ")(
-    source = (-1, -10) :: (0, 0) :: (1, 10) :: (2, 20) :: (3, 30) :: (4, 40) :: (5, 50) :: Nil,
-    target = (-1, -1) :: (1, 1) :: (2, 2) :: (3, 3) :: (5, 5) :: Nil,
-    mergeOn = "s.key = t.key AND t.value > 0 AND s.key < 5",
-    update(condition = "s.key < 2", set = "key = s.key, value = s.value"),
-    delete(condition = "s.key < 3"),
-    insert(condition = "s.key > 1", values = "(key, value) VALUES (s.key, s.value)"))(
-    result = Seq(
-      (-1, -1), // (-1, -1) not matched with (-1, -10) by target-only condition 't.value > 0', so
-                // not updated, But (-1, -10) not inserted as insert condition is 's.key > 1'
-                // (0, 0) not matched any target but not inserted as insert condition is 's.key > 1'
-      (1, 10),  // (1, 1) matched with (1, 10) and updated as update condition is 's.key < 2'
-                // (2, 2) matched with (2, 20) and deleted as delete condition is 's.key < 3'
-      (3, 3),   // (3, 3) matched with (3, 30) but neither updated nor deleted as it did not
-                // satisfy update or delete condition
-      (4, 40),  // (4, 40) not matched any target, so inserted as insert condition is 's.key > 1'
-      (5, 5),   // (5, 5) not matched with (5, 50) by source-only condition 's.key < 5', no update
-      (5, 50)   // (5, 50) inserted as inserted as insert condition is 's.key > 1'
-    ))
-
-  test("extended syntax - different # cols in source than target") {
-    val sourceData =
-      (0, 0, 0) :: (1, 10, 100) :: (2, 20, 200) :: (3, 30, 300) :: (4, 40, 400) :: Nil
-    val targetData = (1, 1) :: (2, 2) :: (3, 3) :: Nil
-
-    withTempView("source") {
-      append(targetData.toDF("key", "value"), Nil)
-      sourceData.toDF("key", "value", "extra").createOrReplaceTempView("source")
-      executeMerge(
-        s"$tableSQLIdentifier t",
-        "source s",
-        cond = "s.key = t.key",
-        update(condition = "s.key < 2", set = "key = s.key, value = s.value + s.extra"),
-        delete(condition = "s.key < 3"),
-        insert(condition = "s.key > 1", values = "(key, value) VALUES (s.key, s.value + s.extra)"))
-
-      checkAnswer(
-        readDeltaTableByIdentifier(),
-        Seq(
-          Row(1, 110),  // (1, 1) updated by condition, but not (2, 2) or (3, 3)
-          Row(3, 3),    // neither updated nor deleted as it matched neither condition
-          Row(4, 440)   // (4, 40) inserted by condition, but not (0, 0)
-        ))              // (2, 2) deleted by condition but not (1, 1) or (3, 3)
-    }
-  }
-
-  test("extended syntax - nested data - conditions and actions") {
-    withJsonData(
-      source =
-        """{ "key": { "x": "X1", "y": 1}, "value" : { "a": 100, "b": "B100" } }
-          { "key": { "x": "X2", "y": 2}, "value" : { "a": 200, "b": "B200" } }
-          { "key": { "x": "X3", "y": 3}, "value" : { "a": 300, "b": "B300" } }
-          { "key": { "x": "X4", "y": 4}, "value" : { "a": 400, "b": "B400" } }""",
-      target =
-        """{ "key": { "x": "X1", "y": 1}, "value" : { "a": 1,   "b": "B1" } }
-          { "key": { "x": "X2", "y": 2}, "value" : { "a": 2,   "b": "B2" } }"""
-    ) { case (sourceName, targetName) =>
-      executeMerge(
-        s"$targetName t",
-        s"$sourceName s",
-        cond = "s.key = t.key",
-        update(condition = "s.key.y < 2", set = "key = s.key, value = s.value"),
-        insert(condition = "s.key.x < 'X4'", values = "(key, value) VALUES (s.key, s.value)"))
-
-      checkAnswer(
-        readDeltaTableByIdentifier(),
-        spark.read.json(Seq(
-          """{ "key": { "x": "X1", "y": 1}, "value" : { "a": 100, "b": "B100" } }""", // updated
-          """{ "key": { "x": "X2", "y": 2}, "value" : { "a": 2,   "b": "B2"   } }""", // not updated
-          """{ "key": { "x": "X3", "y": 3}, "value" : { "a": 300, "b": "B300" } }"""  // inserted
-        ).toDS))
-    }
-  }
-
   def testStar(
       name: String)(
       source: Seq[String],
@@ -2856,56 +2921,6 @@ trait MergeIntoSuiteBaseMiscTests extends MergeIntoSuiteBaseMixin {
          { "key": "b", "value" : 2,  "value2" : 2  }
          { "key": "c", "value" : 30, "value2" : 300 }""")
 
-  testExtendedMerge("insert only merge")(
-    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2)  :: Nil,
-    mergeOn = "s.key = t.key",
-    insert(values = "*"))(
-    result = Seq(
-      (0, 0), // inserted
-      (1, 1), // existed previously
-      (2, 2), // existed previously
-      (3, 30) // inserted
-    ))
-
-  testExtendedMerge("insert only merge with insert condition on source")(
-    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2)  :: Nil,
-    mergeOn = "s.key = t.key",
-    insert(values = "*", condition = "s.key = s.value"))(
-    result = Seq(
-      (0, 0), // inserted
-      (1, 1), // existed previously
-      (2, 2)  // existed previously
-    ))
-
-  testExtendedMerge("insert only merge with predicate insert")(
-    source = (0, 0) :: (1, 10) :: (3, 30) :: Nil,
-    target = (1, 1) :: (2, 2)  :: Nil,
-    mergeOn = "s.key = t.key",
-    insert(values = "(t.key, t.value) VALUES (s.key + 10, s.value + 10)"))(
-    result = Seq(
-      (10, 10), // inserted
-      (1, 1), // existed previously
-      (2, 2), // existed previously
-      (13, 40) // inserted
-    ))
-
-  testExtendedMerge(s"insert only merge with multiple matches") (
-    source = (0, 0) :: (1, 10) :: (1, 100) :: (3, 30) :: (3, 300) :: Nil,
-    target = (1, 1) :: (2, 2) :: Nil,
-    mergeOn = "s.key = t.key",
-    insert(values = "(key, value) VALUES (s.key, s.value)")) (
-    result = Seq(
-      (0, 0), // inserted
-      (1, 1), // existed previously
-      (2, 2), // existed previously
-      (3, 30), // inserted
-      (3, 300) // key exists but still inserted
-    )
-  )
-
-
   test("insert only merge - turn off feature flag") {
     withSQLConf(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false") {
       withKeyValueData(
@@ -2916,22 +2931,6 @@ trait MergeIntoSuiteBaseMiscTests extends MergeIntoSuiteBaseMixin {
       }
     }
   }
-
-  testMergeErrorOnMultipleMatches(
-    "unconditional insert only merge - multiple matches when feature flag off",
-    confs = Seq(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false"))(
-    source = (1, 10) :: (1, 100) :: (2, 20) :: Nil,
-    target = (1, 1) :: Nil,
-    mergeOn = "s.key = t.key",
-    insert(values = "(key, value) VALUES (s.key, s.value)"))
-
-  testMergeErrorOnMultipleMatches(
-    "conditional insert only merge - multiple matches when feature flag off",
-    confs = Seq(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false"))(
-    source = (1, 10) :: (1, 100) :: (2, 20) :: (2, 200) :: Nil,
-    target = (1, 1) :: Nil,
-    mergeOn = "s.key = t.key",
-    insert(condition = "s.value = 20", values = "(key, value) VALUES (s.key, s.value)"))
 
   testMergeWithRepartition(
     name = "partition on multiple columns",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuites.scala
@@ -42,12 +42,24 @@ class MergeIntoUnlimitedMergeClausesTestsMergeIntoScalaSuite
   extends MergeIntoUnlimitedMergeClausesTests
   with MergeIntoScalaMixin
 
+class MergeIntoAnalysisExceptionTestsMergeIntoScalaSuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoScalaMixin
+
+class MergeIntoExtendedSyntaxTestsMergeIntoScalaSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoScalaMixin
+
 class MergeIntoSuiteBaseMiscTestsMergeIntoScalaSuite
   extends MergeIntoSuiteBaseMiscTests
   with MergeIntoScalaMixin
 
 class MergeIntoNotMatchedBySourceMergeIntoScalaSuite
   extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoScalaMixin
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoScalaSuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
   with MergeIntoScalaMixin
 
 class MergeIntoSchemaEvolutionCoreTestsMergeIntoScalaSuite
@@ -58,8 +70,16 @@ class MergeIntoSchemaEvolutionBaseTestsMergeIntoScalaSuite
   extends MergeIntoSchemaEvolutionBaseTests
   with MergeIntoScalaMixin
 
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoScalaSuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoScalaMixin
+
 class MergeIntoSchemaEvolutionNotMatchedBySourceTestsMergeIntoScalaSuite
   extends MergeIntoSchemaEvolutionNotMatchedBySourceTests
+  with MergeIntoScalaMixin
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoScalaSuite
+  extends MergeIntoNestedStructInMapEvolutionTests
   with MergeIntoScalaMixin
 
 class MergeIntoNestedStructEvolutionTestsMergeIntoScalaSuite
@@ -517,6 +537,136 @@ class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedC
   with MergeCDCMixin
   with MergeCDCWithDVsMixin
 
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumnMaOUEJP4QSuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumnMaKF6BE5ISuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDVsPTSQDO3ISuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDVsPMDDY5MISuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMerLW4B7EYSuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMerWY6KAEQSuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumnMappi6HIVMJQSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumnMappiYEOF4FISuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDVsPredGI7G2IQSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDVsPredVYH2KWQSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMergeIUM2FZ5ISuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMergeIRM5BF4QSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
 class MergeIntoSuiteBaseMiscTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
   extends MergeIntoSuiteBaseMiscTests
   with MergeIntoSQLMixin
@@ -639,6 +789,71 @@ class MergeIntoNotMatchedBySourceMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnable
 
 class MergeIntoNotMatchedBySourceMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMergeInFNSOPWQSuite
   extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumCHJK75ASuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumZGORQEQSuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoD5GU4DXASuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDFCCS47ISuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledJSR4ACISuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledOXR24OASuite
+  extends MergeIntoNotMatchedBySourceWithCDCSuite
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with CDCEnabled
@@ -777,6 +992,71 @@ class MergeIntoSchemaEvolutionBaseTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDC
   with MergeCDCMixin
   with MergeCDCWithDVsMixin
 
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatEWFH7SYSuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatU6UMQEYSuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatXC5JFGYSuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatBWA6HOQSuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatV7A3XDISuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatJAGZ2LASuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatNK6SWUYSuite
+  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
 class MergeIntoSchemaEvolutionNotMatchedBySourceTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
   extends MergeIntoSchemaEvolutionNotMatchedBySourceTests
   with MergeIntoSQLMixin
@@ -834,6 +1114,71 @@ class MergeIntoSchemaEvolutionNotMatchedBySourceTestsMergeIntoSQLDeltaDMLTestUti
 
 class MergeIntoSchemaEvolutionNotMatchedBySourceTestsMergeIntoSQLDeltaDMLTestUtilsPathBaYXEVIKQSuite
   extends MergeIntoSchemaEvolutionNotMatchedBySourceTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
+  extends MergeIntoNestedStructInMapEvolutionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
+  extends MergeIntoNestedStructInMapEvolutionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltJBCWZXISuite
+  extends MergeIntoNestedStructInMapEvolutionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltJW3EETISuite
+  extends MergeIntoNestedStructInMapEvolutionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergSRCUATQSuite
+  extends MergeIntoNestedStructInMapEvolutionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergKSC2XPASuite
+  extends MergeIntoNestedStructInMapEvolutionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
+  extends MergeIntoNestedStructInMapEvolutionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEKN3IGDASuite
+  extends MergeIntoNestedStructInMapEvolutionTests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEDRQIUAISuite
+  extends MergeIntoNestedStructInMapEvolutionTests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with CDCEnabled

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
@@ -59,7 +59,7 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
    * returns.
    */
   def withTempDir(prefix: String)(f: File => Unit): Unit = {
-    val path = Utils.createTempDir(namePrefix = prefix)
+    val path = Utils.createTempDir(namePrefix = s"$prefix-${UUID.randomUUID()}")
     try f(path) finally Utils.deleteRecursively(path)
   }
 
@@ -68,7 +68,7 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
    * passed to `f` and will be deleted after `f` returns.
    */
   def withTempPath(prefix: String)(f: File => Unit): Unit = {
-    val path = Utils.createTempDir(namePrefix = prefix)
+    val path = Utils.createTempDir(namePrefix = s"$prefix-${UUID.randomUUID()}")
     path.delete()
     try f(path) finally Utils.deleteRecursively(path)
   }
@@ -79,7 +79,8 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
    */
   protected def withTempPaths(numPaths: Int, prefix: String)(f: Seq[File] => Unit): Unit = {
     val files =
-      Seq.fill[File](numPaths)(Utils.createTempDir(namePrefix = prefix).getCanonicalFile)
+      Seq.fill[File](numPaths)(
+        Utils.createTempDir(namePrefix = s"$prefix-${UUID.randomUUID()}").getCanonicalFile)
     files.foreach(_.delete())
     try f(files) finally {
       files.foreach(Utils.deleteRecursively)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
